### PR TITLE
fix: revert publish block

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,11 +1,10 @@
 name: Python Publish Workflow
+
 on:
   workflow_call:
 
 jobs:
   publish:
-    # manually disabled here for now
-    if: false
     uses: microsoft/action-python/.github/workflows/publish.yml@0.7.3
     secrets:
       PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}


### PR DESCRIPTION
The block to the GitHub publish option failed. So remove ti.