### PR TITLE
dependencies: upgrade pyright and upgrade cache github action

### DIFF
--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -20,7 +20,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
           version: "1.3.2"
       - name: Cache dependencies
         id: cache-deps
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .venv
           key: pydeps-${{ hashFiles('**/poetry.lock') }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,13 +21,13 @@ pytest-cov = "^4.0.0"
 pytest-xdist = "^3.2.0"
 pre-commit = "^3.1.0"
 interrogate = "^1.5.0"
-pyright = "^1.1.309"
+pyright = "^1.1.391"
 mkdocs-material = "^9.1.6"
 mkdocstrings = { extras = ["python"], version = "^0.21.2" }
 mkdocs-gen-files = "^0.4.0"
 mkdocs-literate-nav = "^0.6.0"
 setuptools = "^74.1.2"
-moto = {extras = ["all", "ec2", "s3"], version = "^5.0.22"}
+moto = { extras = ["all", "ec2", "s3"], version = "^5.0.22" }
 
 [tool.coverage.report]
 fail_under = 85.0


### PR DESCRIPTION
This PR closes #70.

And this also takes care to upgrade the github action caching in some of the workflows.