### PR TITLE
feature: adding `Silo` specific JSON schema

### DIFF
--- a/src/sr2silo/process/interface.py
+++ b/src/sr2silo/process/interface.py
@@ -6,7 +6,7 @@ import json
 import logging
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, RootModel, ValidationError, root_validator
+from pydantic import BaseModel, RootModel, ValidationError, model_validator
 
 logging.basicConfig(
     level=logging.DEBUG, format="%(asctime)s - %(levelname)s - %(message)s"
@@ -15,7 +15,6 @@ logging.basicConfig(
 
 # --- New Pydantic schemas for AlignedRead JSON format ---
 class ReadMetadata(BaseModel):
-
     read_id: str
     sequencing_date: str
     location_name: str
@@ -59,7 +58,7 @@ class AlignedReadSchema(BaseModel):
     unalignedNucleotideSequences: UnalignedNucleotideSequences
     alignedAminoAcidSequences: AminoAcidSequences
 
-    @root_validator(pre=True)
+    @model_validator(mode="before")
     def add_default_metadata(cls, values):
         if "metadata" not in values or values["metadata"] is None:
             values["metadata"] = {

--- a/src/sr2silo/process/interface.py
+++ b/src/sr2silo/process/interface.py
@@ -6,12 +6,14 @@ import json
 import logging
 from typing import Any, Dict, List, Optional
 
-from sr2silo.silo_aligned_read import AlignedReadSchema
 from pydantic import ValidationError
+
+from sr2silo.silo_aligned_read import AlignedReadSchema
 
 logging.basicConfig(
     level=logging.DEBUG, format="%(asctime)s - %(levelname)s - %(message)s"
 )
+
 
 class NucInsertion:
     """A nuclotide insertion."""

--- a/src/sr2silo/process/interface.py
+++ b/src/sr2silo/process/interface.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 logging.basicConfig(
     level=logging.DEBUG, format="%(asctime)s - %(levelname)s - %(message)s"
@@ -48,14 +48,16 @@ class AlignedRead:
         nucleotide_insertions: List[NucInsertion],
         amino_acid_insertions: AAInsertionSet,
         aligned_amino_acid_sequences: AASequenceSet,
+        metadata: Optional[Dict[str, str]] = None,
     ):
+        """Initialize with a AlignedRead object."""
         self.read_id = read_id
         self.unaligned_nucleotide_sequences = unaligned_nucleotide_sequences
         self.aligned_nucleotide_sequences = aligned_nucleotide_sequences
         self.nucleotide_insertions = nucleotide_insertions
         self.amino_acid_insertions = amino_acid_insertions
         self.aligned_amino_acid_sequences = aligned_amino_acid_sequences
-
+        self.metadata = metadata
         self._validate_types()
 
     def _validate_types(self):
@@ -86,6 +88,10 @@ class AlignedRead:
                 f"aligned_amino_acid_sequences must be a dict, got "
                 f"{type(self.aligned_amino_acid_sequences).__name__}"
             )
+        if self.metadata is not None and not isinstance(self.metadata, dict):
+            raise TypeError(
+                f"metadata must be a dict, got {type(self.metadata).__name__}"
+            )
 
     def set_nuc_insertion(self, nuc_insertion: NucInsertion):
         """Append a nucleotide insertion to the list of nucleotide insertions."""
@@ -114,11 +120,15 @@ class AlignedRead:
             },
             "alignedAminoAcidSequences": self.aligned_amino_acid_sequences.to_dict(),
         }
+        if self.metadata:
+            json_representation["metadata"] = self.metadata
         return json_representation
 
+    # TODO: add to_silo_json method with read_id nested in metadata
+
     def __str__(self) -> str:
-        """toString method ad JSON string."""
-        return json.dumps(self.to_dict())
+        """toString method as pretty JSON string."""
+        return json.dumps(self.to_dict(), indent=2)
 
     @staticmethod
     def from_str(data: str) -> AlignedRead:

--- a/src/sr2silo/process/translate_align.py
+++ b/src/sr2silo/process/translate_align.py
@@ -129,14 +129,14 @@ def nuc_to_aa_alignment(
         db_ref_fp = Path(in_aa_reference_fp.stem + ".temp.db")
         # ==== Make Sequence DB ====
         logging.info("Diamond makedb")
-        print("== Making Sequence DB ==")
+        logging.info("== Making Sequence DB ==")
         result = os.system(f"diamond makedb --in {in_aa_reference_fp} -d {db_ref_fp}")
         if result != 0:
             raise RuntimeError(
                 "Error occurred while making sequence DB with diamond makedb"
             )
     except Exception as e:
-        print(f"An error occurred while making sequence DB: {e}")
+        logging.error(f"An error occurred while making sequence DB: {e}")
         raise
 
     try:
@@ -153,7 +153,7 @@ def nuc_to_aa_alignment(
                 "Error occurred while aligning to AA with diamond blastx"
             )
     except Exception as e:
-        print(f"An error occurred while aligning to AA: {e}")
+        logging.error(f"An error occurred while aligning to AA: {e}")
         raise
     finally:
         # Ensure the temporary fasta file is deleted
@@ -268,8 +268,6 @@ def read_in_AlignedReads_aa_seq_and_ins(
                 padded_aa_alignment = convert.pad_alignment(
                     aa_aligned, pos, gene_set.get_gene_length(gene_name)
                 )
-
-                print(f"type of aa_insertions: {type(aa_insertions)}")
 
                 aa_ins = [
                     AAInsertion(position=ins_pos, sequence=ins_seq)

--- a/src/sr2silo/silo_aligned_read.py
+++ b/src/sr2silo/silo_aligned_read.py
@@ -1,0 +1,49 @@
+"""SILO-specific pydantic schemas for AlignedRead JSON format."""
+
+from __future__ import annotations
+import json
+import logging
+from typing import Any, Dict, List, Optional
+from pydantic import BaseModel, RootModel, model_validator
+
+logging.basicConfig(level=logging.DEBUG, format="%(asctime)s - %(levelname)s - %(message)s")
+
+# --- SILO-specific pydantic schemas for AlignedRead JSON format ---
+class ReadMetadata(BaseModel):
+    read_id: str
+    sequencing_date: str
+    location_name: str
+    batch_id: str
+    read_length: str
+    primer_protocol: str
+    location_code: str
+    flow_cell_serial_number: str
+    nextclade_reference: str
+    sequencing_well_position: str
+    sample_id: str
+    sampling_date: str
+    primer_protocol_name: str
+
+class AlignedNucleotideSequences(BaseModel):
+    main: str
+
+class UnalignedNucleotideSequences(BaseModel):
+    main: str
+
+class NucleotideInsertions(BaseModel):
+    main: List[str]
+
+class AminoAcidSequences(RootModel):
+    root: Dict[str, Optional[str]]
+
+class AminoAcidInsertions(RootModel):
+    root: Dict[str, List[str]]
+
+class AlignedReadSchema(BaseModel):
+    metadata: Optional[ReadMetadata] = None
+    nucleotideInsertions: NucleotideInsertions
+    aminoAcidInsertions: AminoAcidInsertions
+    alignedNucleotideSequences: AlignedNucleotideSequences
+    unalignedNucleotideSequences: UnalignedNucleotideSequences
+    alignedAminoAcidSequences: AminoAcidSequences
+

--- a/src/sr2silo/silo_aligned_read.py
+++ b/src/sr2silo/silo_aligned_read.py
@@ -12,8 +12,9 @@ logging.basicConfig(
 )
 
 
-# --- SILO-specific pydantic schemas for AlignedRead JSON format ---
 class ReadMetadata(BaseModel):
+    """SILO-specific pydantic schema for ReadMetadata JSON format."""
+
     read_id: str
     sequencing_date: str
     location_name: str
@@ -30,26 +31,38 @@ class ReadMetadata(BaseModel):
 
 
 class AlignedNucleotideSequences(BaseModel):
+    """SILO-specific pydantic schema for AlignedNucleotideSequences JSON format."""
+
     main: str
 
 
 class UnalignedNucleotideSequences(BaseModel):
+    """SILO-specific pydantic schema for UnalignedNucleotideSequences JSON format."""
+
     main: str
 
 
 class NucleotideInsertions(BaseModel):
+    """SILO-specific pydantic schema for NucleotideInsertions JSON format."""
+
     main: List[str]
 
 
 class AminoAcidSequences(RootModel):
+    """SILO-specific pydantic schema for AminoAcidSequences JSON format."""
+
     root: Dict[str, Optional[str]]
 
 
 class AminoAcidInsertions(RootModel):
+    """SILO-specific pydantic schema for AminoAcidInsertions JSON format."""
+
     root: Dict[str, List[str]]
 
 
 class AlignedReadSchema(BaseModel):
+    """SILO-specific pydantic schema for AlignedRead JSON format."""
+
     metadata: Optional[ReadMetadata] = None
     nucleotideInsertions: NucleotideInsertions
     aminoAcidInsertions: AminoAcidInsertions

--- a/src/sr2silo/silo_aligned_read.py
+++ b/src/sr2silo/silo_aligned_read.py
@@ -1,12 +1,16 @@
 """SILO-specific pydantic schemas for AlignedRead JSON format."""
 
 from __future__ import annotations
-import json
-import logging
-from typing import Any, Dict, List, Optional
-from pydantic import BaseModel, RootModel, model_validator
 
-logging.basicConfig(level=logging.DEBUG, format="%(asctime)s - %(levelname)s - %(message)s")
+import logging
+from typing import Dict, List, Optional
+
+from pydantic import BaseModel, RootModel
+
+logging.basicConfig(
+    level=logging.DEBUG, format="%(asctime)s - %(levelname)s - %(message)s"
+)
+
 
 # --- SILO-specific pydantic schemas for AlignedRead JSON format ---
 class ReadMetadata(BaseModel):
@@ -24,20 +28,26 @@ class ReadMetadata(BaseModel):
     sampling_date: str
     primer_protocol_name: str
 
+
 class AlignedNucleotideSequences(BaseModel):
     main: str
+
 
 class UnalignedNucleotideSequences(BaseModel):
     main: str
 
+
 class NucleotideInsertions(BaseModel):
     main: List[str]
+
 
 class AminoAcidSequences(RootModel):
     root: Dict[str, Optional[str]]
 
+
 class AminoAcidInsertions(RootModel):
     root: Dict[str, List[str]]
+
 
 class AlignedReadSchema(BaseModel):
     metadata: Optional[ReadMetadata] = None
@@ -46,4 +56,3 @@ class AlignedReadSchema(BaseModel):
     alignedNucleotideSequences: AlignedNucleotideSequences
     unalignedNucleotideSequences: UnalignedNucleotideSequences
     alignedAminoAcidSequences: AminoAcidSequences
-

--- a/tests/process/conftest.py
+++ b/tests/process/conftest.py
@@ -1,0 +1,31 @@
+"""
+Fixtures for the process module.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict
+
+import pytest
+
+import sr2silo.process.translate_align as translate_align
+from sr2silo.process.interface import AlignedRead
+
+
+@pytest.fixture
+def aligned_reads() -> Dict[str, AlignedRead]:
+    """
+    Small mock data with 42 real reads from the combined.bam file.
+
+    Current dataset misses Amino Acid Insertions - i.e. not tested here.
+    """
+
+    nuc_ref_fp = Path("resources/sars-cov-2/nuc_reference_genomes.fasta")
+    aa_ref_fp = Path("resources/sars-cov-2/aa_reference_genomes.fasta")
+    nuc_alignment_fp = Path("tests/data/bam/combined.bam")
+
+    aligned_reads = translate_align.parse_translate_align(
+        nuc_ref_fp, aa_ref_fp, nuc_alignment_fp
+    )
+    return aligned_reads

--- a/tests/process/test_interface.py
+++ b/tests/process/test_interface.py
@@ -59,3 +59,14 @@ def test_aa_insertion_set():
 def test_aa_sequence_set():
     """Test AASequenceSet functionality."""
     raise NotImplementedError
+
+
+# test the to_silo_json method
+def test_to_silo_json(aligned_reads):
+    """Test to_silo_json functionality."""
+
+    # for all reads in aligned_reads, test the to_silo_json method
+    for read in aligned_reads.values():
+        print(read.to_silo_json())
+
+    raise NotImplementedError

--- a/tests/process/test_interface.py
+++ b/tests/process/test_interface.py
@@ -2,21 +2,20 @@
 
 from __future__ import annotations
 
-from sr2silo.silo_aligned_read import ReadMetadata
-
 import pytest
 from pydantic import ValidationError
 
 from sr2silo.process.interface import (
-    NucInsertion,
     AAInsertion,
-    AlignedRead,
-    GeneName,
-    Gene,
-    GeneSet,
     AAInsertionSet,
     AASequenceSet,
+    AlignedRead,
+    Gene,
+    GeneName,
+    GeneSet,
+    NucInsertion,
 )
+from sr2silo.silo_aligned_read import ReadMetadata
 
 
 def test_nuc_insertion():
@@ -139,4 +138,3 @@ def test_to_silo_json():
             read.to_silo_json()
         except ValidationError as e:
             pytest.fail(f"Validation error: {e}")
-

--- a/tests/process/test_translation_aligment.py
+++ b/tests/process/test_translation_aligment.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import copy
 import logging
 from pathlib import Path
-from typing import Dict
 
 import pytest
 
@@ -35,24 +34,6 @@ def test_translate():
         "nextstrain/sars-cov-2/XBB",
     )
     assert True
-
-
-@pytest.fixture
-def aligned_reads() -> Dict[str, AlignedRead]:
-    """
-    Small mock data with 42 real reads from the combined.bam file.
-
-    Current dataset misses Amino Acid Insertions - i.e. not tested here.
-    """
-
-    nuc_ref_fp = Path("resources/sars-cov-2/nuc_reference_genomes.fasta")
-    aa_ref_fp = Path("resources/sars-cov-2/aa_reference_genomes.fasta")
-    nuc_alignment_fp = Path("tests/data/bam/combined.bam")
-
-    aligned_reads = translate_align.parse_translate_align(
-        nuc_ref_fp, aa_ref_fp, nuc_alignment_fp
-    )
-    return aligned_reads
 
 
 def test_parse_translate_align(aligned_reads):


### PR DESCRIPTION
This PR adresses 
- #95 

Adding a still loose pydantic schema for the JSON of single read. 

Having the JSON print separate from he internal representation keeps the processing of read data separate from SILO conventions.