### PR TITLE
bug: workflow env misses `sr2silo` in namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,11 +40,10 @@ activate-dev-env:
 activate-workflow-env:
 	@echo "Activate the workflow environment with: conda activate sr2silo-workflow"
 
-.PHONY: install-poetry
-install-poetry:
-	@echo "Installing Poetry in the sr2silo environment..."
-	@conda run -n sr2silo pip install poetry
-	@conda run -n sr2silo poetry install
+.PHONY: install
+install:
+	@echo "Installing the package in the sr2silo environment..."
+	@conda run -n sr2silo pip install -e .
 
 .PHONY: install-poetry-dev
 install-poetry-dev:
@@ -52,8 +51,13 @@ install-poetry-dev:
 	@conda run -n sr2silo-dev pip install poetry
 	@conda run -n sr2silo-dev poetry install --with dev
 
+.PHONY: install-workflow
+install-workflow:
+	@echo "Installing the package in the sr2silo-workflow environment..."
+	@conda run -n sr2silo-workflow pip install -e .
+
 .PHONY: setup
-setup: create-env activate-env install-poetry
+setup: create-env activate-env install
 	@echo "Environment setup complete."
 
 .PHONY: setup-dev
@@ -61,7 +65,7 @@ setup-dev: create-dev-env activate-dev-env install-poetry-dev
 	@echo "Development environment setup complete."
 
 .PHONY: setup-workflow
-setup-workflow: create-workflow-env activate-workflow-env
+setup-workflow: create-workflow-env activate-workflow-env install-workflow
 	@echo "Workflow environment setup complete."
 
 .PHONY: setup-all

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ click = "^8.1.8"
 pydantic = "^2.10.6"
 zstandard = "^0.23.0"
 typer = "^0.15.1"
-biopython = "^1.85"
+biopython = "^1.83"
 pysam = "^0.23.0"
 
 


### PR DESCRIPTION
This PR fixes the `sr2silo` to be visible to the PATH.