### PR TITLE
diamond: required manual temp dir handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ sr2silo outputs per read a JSON (mock output):
 
 The total output is handled in an `.ndjson.zst`.
 
+### Resource Requirements
+
+When running sr2silo, particularly the `import-to-loculus` command, be aware of memory and storage requirements:
+
+- Standard configuration uses 8GB RAM and one CPU core
+- Processing batches of 100k reads requires ~3GB RAM plus ~3GB for Diamond
+- Temporary storage needs (especially on clusters) can reach 30-50GB
+
+For detailed information about resource requirements, especially for cluster environments, please refer to the [Resource Requirements documentation](docs/usage/resource_requirements.md).
+
 ### Wrangling Short-Read Genomic Alignments for SILO Database
 
 Originally this was started for wargeling short-read genomic alignments for from wastewater-sampling, into a format for easy import into [Loculus](https://github.com/loculus-project/loculus) and its sequence database SILO.

--- a/docs/usage/resource_requirements.md
+++ b/docs/usage/resource_requirements.md
@@ -1,0 +1,31 @@
+# Resource Requirements
+
+When running sr2silo, especially the `--import to loculus` command, you should be aware of the following resource requirements:
+
+## Memory Requirements
+
+- **Standard Resources**: The default Snakemake configuration uses 8 GB RAM and one CPU core
+- **Actual Usage**: 
+  - sr2silo processes in batches of 100k reads at a time, requiring approximately 3 GB of RAM
+  - An additional 3 GB of RAM is needed for running Diamond for amino acid translation and alignment
+
+## Storage Requirements
+
+- **Temporary Space**: 
+  - sr2silo itself requires some temporary directory space
+  - Diamond may require up to 30 GB of temporary storage
+  - Ideally, this should be on high I/O storage
+
+## Cluster Environment Configuration
+
+When running on a personal computer, standard temporary directories are usually sufficient as long as you have free disk space. However, in a cluster environment:
+
+1. Set the environment variable `TMPDIR` to a location with at least 50 GB of free space:
+
+```bash
+export TMPDIR=/path/to/temp/directory
+```
+
+2. Make sure this directory has good I/O performance for optimal processing speed
+
+This configuration will help prevent issues with temporary file storage during the processing of large datasets.

--- a/docs/usage/resource_requirements.md
+++ b/docs/usage/resource_requirements.md
@@ -20,7 +20,7 @@ When running sr2silo, especially the `--import to loculus` command, you should b
 
 When running on a personal computer, standard temporary directories are usually sufficient as long as you have free disk space. However, in a cluster environment:
 
-1. Set the environment variable `TMPDIR` to a location with at least 50 GB of free space:
+1. Set the environment variable `TMPDIR` to a location with at least 50 GB of free space per run:
 
 ```bash
 export TMPDIR=/path/to/temp/directory

--- a/src/sr2silo/import_to_loculus.py
+++ b/src/sr2silo/import_to_loculus.py
@@ -9,7 +9,6 @@ import os
 import tempfile
 from pathlib import Path
 
-from memory_profiler import profile
 
 from sr2silo.config import (
     get_keycloak_token_url,
@@ -132,7 +131,6 @@ def submit_to_silo(result_dir: Path, s3_link: str) -> bool:
         return False
 
 
-@profile
 def nuc_align_to_silo_njson(
     input_file: Path,
     sample_id: str,

--- a/src/sr2silo/main.py
+++ b/src/sr2silo/main.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from pathlib import Path
 from typing import Annotated
 
@@ -117,6 +118,14 @@ def import_to_loculus(
     logging.info(f"Using sample_id: {sample_id}")
     logging.info(f"Using batch_id: {batch_id}")
     logging.info(f"Upload to S3 and submit to SILO: {upload}")
+
+    # check if $TMPDIR is set, if not use /tmp
+    if "TMPDIR" in os.environ:
+        temp_dir = Path(os.environ["TMPDIR"])
+        logging.info(f"Recognize temporary directory set in Env: {temp_dir}")
+        logging.info(
+            "This will be used for amino acid translation and alignment - by diamond."
+        )
 
     ci_env = is_ci_environment()
     logging.info(f"Running in CI environment: {ci_env}")

--- a/src/sr2silo/process/translate_align.py
+++ b/src/sr2silo/process/translate_align.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from typing import Callable, Dict, List
 
 import zstandard as zstd
-from memory_profiler import profile
 from tqdm import tqdm
 
 import sr2silo.process.convert as convert
@@ -93,7 +92,6 @@ def translate_nextclade(
             command = ["mv", f"{temp_dir}/results", str(result_path)]
 
 
-@profile
 def nuc_to_aa_alignment(
     in_nuc_alignment_fp: Path,
     in_aa_reference_fp: Path,
@@ -144,6 +142,8 @@ def nuc_to_aa_alignment(
             logging.info(
                 f"Temporary directory not set in Env. Using output dir default: {temp_dir_path}"
             )
+
+        logging.info(f"Using temporary directory for diamond: {temp_dir_path}")
 
         # temporary file file for amino acid reference DB
         db_ref_fp = temp_dir_path / Path(in_aa_reference_fp.stem + ".temp.db")
@@ -226,7 +226,6 @@ def nuc_to_aa_alignment(
     return None
 
 
-@profile
 def make_read_with_nuc_seq(
     fastq_nuc_alignment_file: Path, nuc_reference_length: int, gene_set: GeneSet
 ) -> Dict[str, AlignedRead]:
@@ -290,7 +289,6 @@ def make_read_with_nuc_seq(
     return aligned_reads
 
 
-@profile
 def enrich_read_with_nuc_ins(
     aligned_reads: dict[str, AlignedRead], fasta_nuc_insertions_file: Path
 ) -> Dict[str, AlignedRead]:
@@ -311,7 +309,6 @@ def enrich_read_with_nuc_ins(
     return aligned_reads
 
 
-@profile
 def enrich_read_with_aa_seq(
     aligned_reads: Dict[str, AlignedRead],
     fasta_aa_alignment_file: Path,
@@ -359,7 +356,6 @@ def enrich_read_with_aa_seq(
     return aligned_reads
 
 
-@profile
 def parse_translate_align(
     nuc_reference_fp: Path, aa_reference_fp: Path, nuc_alignment_fp: Path
 ) -> Dict[str, AlignedRead]:
@@ -449,7 +445,6 @@ def curry_read_with_metadata(metadata_fp: Path) -> Callable[[AlignedRead], Align
     return enrich_single_read
 
 
-@profile
 def process_bam_files(bam_splits_fps, nuc_reference_fp, aa_reference_fp, metadata_fp):
     """Generator to process BAM files and yield JSON strings."""
 
@@ -463,7 +458,6 @@ def process_bam_files(bam_splits_fps, nuc_reference_fp, aa_reference_fp, metadat
             yield enriched_read.to_silo_json()
 
 
-@profile
 def parse_translate_align_in_batches(
     nuc_reference_fp: Path,
     aa_reference_fp: Path,

--- a/src/sr2silo/process/translate_align.py
+++ b/src/sr2silo/process/translate_align.py
@@ -133,6 +133,18 @@ def nuc_to_aa_alignment(
         logging.info("FASTA conversion for AA alignment")
         convert.bam_to_fasta(in_nuc_alignment_fp, fasta_nuc_for_aa_alignment)
 
+        # check if temp_dir is specieifed in the environment
+        if "TMPDIR" in os.environ:
+            temp_dir_path = Path(os.environ["TMPDIR"])
+            logging.info(f"Recognize temporary directory set in Env: {temp_dir_path}")
+            logging.info(
+                "This will be used for amino acid translation and alignment - by diamond."
+            )
+        else:
+            logging.info(
+                f"Temporary directory not set in Env. Using output dir default: {temp_dir_path}"
+            )
+
         # temporary file file for amino acid reference DB
         db_ref_fp = temp_dir_path / Path(in_aa_reference_fp.stem + ".temp.db")
         try:
@@ -192,6 +204,8 @@ def nuc_to_aa_alignment(
                     "1",
                     "--block-size",
                     "0.5",
+                    "--tmpdir",
+                    str(temp_dir_path),
                 ],
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,

--- a/workflow/README.md
+++ b/workflow/README.md
@@ -3,3 +3,5 @@
 This directory contains some workflows implemented in `snakemake` to enable,
 rapid historical data conversion and import to JSON like format, ready for
 import in SILO.
+
+**Note:** Please check the documentation for information on resource requirements when running sr2silo, especially in cluster environments.

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -3,6 +3,8 @@
 """
 
 import yaml
+import os
+from pathlib import Path
 
 
 configfile: "workflow/config.yaml"
@@ -11,6 +13,13 @@ configfile: "workflow/config.yaml"
 # Load configuration
 with open("workflow/config.yaml", "r") as file:
     config = yaml.safe_load(file)
+
+
+# Check for TMPDIR environment variable
+temp_dir = None
+if "TMPDIR" in os.environ:
+    temp_dir = Path(os.environ["TMPDIR"])
+    print(f"Using TMPDIR environment variable: {temp_dir}")
 
 
 def get_batch_id(sample_id):
@@ -46,11 +55,13 @@ rule process_sample:
         primers_file=config["PRIMERS_FILE"],
         nuc_reference=config["NUC_REFERENCE"],
         aa_reference=config["NUC_REFERENCE"],
+        temp_dir=temp_dir,
     log:
         "logs/sr2silo/process_sample/sampleId_{sample_id}_batchId_{batch_id}.log",  # Clearer wildcard separation
     shell:
         """
         echo "Processing sample {params.sample_id} started" >> {log}
+        {{"TMPDIR=" + str(params.temp_dir) if params.temp_dir else ""}} \
         sr2silo import-to-loculus \
             --input-file {input.sample_fp} \
             --sample-id {params.sample_id} \

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -7,14 +7,11 @@ import os
 from pathlib import Path
 
 
-#CONFIG="workflow/config.yaml"
-CONFIG="workflow/config_euler.yaml"
-
-configfile: CONFIG
+configfile: "workflow/config.yaml"
 
 
 # Load configuration
-with open(CONFIG, "r") as file:
+with open("workflow/config.yaml", "r") as file:
     config = yaml.safe_load(file)
 
 
@@ -63,6 +60,8 @@ rule process_sample:
         "logs/sr2silo/process_sample/sampleId_{sample_id}_batchId_{batch_id}.log",  # Clearer wildcard separation
     shell:
         """
+        echo "Processing sample {params.sample_id} started" >> {log}
+        {{"TMPDIR=" + str(params.temp_dir) if params.temp_dir else ""}} \
         sr2silo import-to-loculus \
             --input-file {input.sample_fp} \
             --sample-id {params.sample_id} \
@@ -72,4 +71,5 @@ rule process_sample:
             --output-fp {output.result_fp} \
             --reference {params.nuc_reference} \
             --no-upload 2>&1 | tee -a {log}
+        echo "Processing sample {params.sample_id} completed" >> {log}
         """

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -6,8 +6,8 @@ import yaml
 import os
 from pathlib import Path
 
-
-configfile: "workflow/config.yaml"
+configfile: "workflow/config_euler.yaml"
+# configfile: "workflow/config.yaml"
 
 
 # Load configuration

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -60,8 +60,6 @@ rule process_sample:
         "logs/sr2silo/process_sample/sampleId_{sample_id}_batchId_{batch_id}.log",  # Clearer wildcard separation
     shell:
         """
-        echo "Processing sample {params.sample_id} started" >> {log}
-        {{"TMPDIR=" + str(params.temp_dir) if params.temp_dir else ""}} \
         sr2silo import-to-loculus \
             --input-file {input.sample_fp} \
             --sample-id {params.sample_id} \
@@ -71,5 +69,4 @@ rule process_sample:
             --output-fp {output.result_fp} \
             --reference {params.nuc_reference} \
             --no-upload 2>&1 | tee -a {log}
-        echo "Processing sample {params.sample_id} completed" >> {log}
         """

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -6,12 +6,15 @@ import yaml
 import os
 from pathlib import Path
 
-configfile: "workflow/config_euler.yaml"
-# configfile: "workflow/config.yaml"
+
+#CONFIG="workflow/config.yaml"
+CONFIG="workflow/config_euler.yaml"
+
+configfile: CONFIG
 
 
 # Load configuration
-with open("workflow/config.yaml", "r") as file:
+with open(CONFIG, "r") as file:
     config = yaml.safe_load(file)
 
 

--- a/workflow/config_euler.yaml
+++ b/workflow/config_euler.yaml
@@ -1,4 +1,4 @@
-BASE_SAMPLE_DIR: "tests/data/samples"
+BASE_SAMPLE_DIR: "/cluster/project/pangolin/gordon_samples/samples"
 SAMPLE_BATCH_IDS:
   A1_05_2024_10_08: "20241024_2411515907"
   A2_17_2024_10_13: "20241024_2411515907"
@@ -27,4 +27,4 @@ SAMPLE_BATCH_IDS:
 TIMELINE_FILE: "/cluster/project/pangolin/work-vp-test/variants/timeline.tsv"
 PRIMERS_FILE: "/cluster/project/pangolin/work-new-variants/references/primers.yaml"
 NUC_REFERENCE: "sars-cov-2"
-RESULTS_DIR: "results"
+RESULTS_DIR: "/cluster/project/pangolin/gordon_samples/temp_test"

--- a/workflow/submit_workflow.sh
+++ b/workflow/submit_workflow.sh
@@ -2,10 +2,10 @@
 sbatch \
     --mail-type=END \
     --ntasks=1 \
-    --cpus-per-task=24 \
+    --cpus-per-task=12 \
     --mem-per-cpu=8G \
     --tmp=50G \
     --time=2:00:00 \
     -o /cluster/home/koehng/logs/sr2silo.out \
     -e /cluster/home/koehng/logs/sr2silo.err \
-    snakemake -c 24
+    snakemake -c 12

--- a/workflow/submit_workflow.sh
+++ b/workflow/submit_workflow.sh
@@ -3,7 +3,8 @@ sbatch \
     --mail-type=END \
     --ntasks=1 \
     --cpus-per-task=24 \
-    --mem-per-cpu=32000 \
+    --mem-per-cpu=8G \
+    --temp=50G \
     --time=2:00:00 \
     -o /cluster/home/koehng/logs/sr2silo.out \
     -e /cluster/home/koehng/logs/sr2silo.err \

--- a/workflow/submit_workflow.sh
+++ b/workflow/submit_workflow.sh
@@ -4,7 +4,7 @@ sbatch \
     --ntasks=1 \
     --cpus-per-task=24 \
     --mem-per-cpu=8G \
-    --temp=50G \
+    --tmp=50G \
     --time=2:00:00 \
     -o /cluster/home/koehng/logs/sr2silo.out \
     -e /cluster/home/koehng/logs/sr2silo.err \

--- a/workflow/submit_workflow.sh
+++ b/workflow/submit_workflow.sh
@@ -2,10 +2,10 @@
 sbatch \
     --mail-type=END \
     --ntasks=1 \
-    --cpus-per-task=12 \
+    --cpus-per-task=4 \
     --mem-per-cpu=8G \
-    --tmp=50G \
+    --tmp=160G \
     --time=2:00:00 \
     -o /cluster/home/koehng/logs/sr2silo.out \
     -e /cluster/home/koehng/logs/sr2silo.err \
-    snakemake -c 12
+    snakemake -c 4


### PR DESCRIPTION
The culprit may be something else. 

`Diamond` required temp directories, which be default just point to the output. 

https://github.com/bbuchfink/diamond/wiki/3.-Command-line-options#memory--performance-options

Here we assign some extra temp storage. 