### PR TITLE
feature / fix: temporary directory handling for amino acid aligment

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ sr2silo outputs per read a JSON (mock output):
 
 The total output is handled in an `.ndjson.zst`.
 
+### Resource Requirements
+
+When running sr2silo, particularly the `import-to-loculus` command, be aware of memory and storage requirements:
+
+- Standard configuration uses 8GB RAM and one CPU core
+- Processing batches of 100k reads requires ~3GB RAM plus ~3GB for Diamond
+- Temporary storage needs (especially on clusters) can reach 30-50GB
+
+For detailed information about resource requirements, especially for cluster environments, please refer to the [Resource Requirements documentation](docs/usage/resource_requirements.md).
+
 ### Wrangling Short-Read Genomic Alignments for SILO Database
 
 Originally this was started for wargeling short-read genomic alignments for from wastewater-sampling, into a format for easy import into [Loculus](https://github.com/loculus-project/loculus) and its sequence database SILO.

--- a/docs/usage/resource_requirements.md
+++ b/docs/usage/resource_requirements.md
@@ -1,0 +1,31 @@
+# Resource Requirements
+
+When running sr2silo, especially the `--import to loculus` command, you should be aware of the following resource requirements:
+
+## Memory Requirements
+
+- **Standard Resources**: The default Snakemake configuration uses 8 GB RAM and one CPU core
+- **Actual Usage**: 
+  - sr2silo processes in batches of 100k reads at a time, requiring approximately 3 GB of RAM
+  - An additional 3 GB of RAM is needed for running Diamond for amino acid translation and alignment
+
+## Storage Requirements
+
+- **Temporary Space**: 
+  - sr2silo itself requires some temporary directory space
+  - Diamond may require up to 30 GB of temporary storage
+  - Ideally, this should be on high I/O storage
+
+## Cluster Environment Configuration
+
+When running on a personal computer, standard temporary directories are usually sufficient as long as you have free disk space. However, in a cluster environment:
+
+1. Set the environment variable `TMPDIR` to a location with at least 50 GB of free space per run:
+
+```bash
+export TMPDIR=/path/to/temp/directory
+```
+
+2. Make sure this directory has good I/O performance for optimal processing speed
+
+This configuration will help prevent issues with temporary file storage during the processing of large datasets.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ mkdocs-literate-nav = "^0.6.0"
 setuptools = "^74.1.2"
 mkdocstrings-python = "^1.13.0"
 genbadge = {extras = ["coverage"], version = "^1.1.1"}
-memory-profiler = "^0.61.0"
 
 [tool.coverage.report]
 fail_under = 75.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ mkdocs-literate-nav = "^0.6.0"
 setuptools = "^74.1.2"
 mkdocstrings-python = "^1.13.0"
 genbadge = {extras = ["coverage"], version = "^1.1.1"}
+memory-profiler = "^0.61.0"
 
 [tool.coverage.report]
 fail_under = 75.0

--- a/src/sr2silo/import_to_loculus.py
+++ b/src/sr2silo/import_to_loculus.py
@@ -9,6 +9,8 @@ import os
 import tempfile
 from pathlib import Path
 
+from memory_profiler import profile
+
 from sr2silo.config import (
     get_keycloak_token_url,
     get_mock_urls,
@@ -130,6 +132,7 @@ def submit_to_silo(result_dir: Path, s3_link: str) -> bool:
         return False
 
 
+@profile
 def nuc_align_to_silo_njson(
     input_file: Path,
     sample_id: str,

--- a/src/sr2silo/import_to_loculus.py
+++ b/src/sr2silo/import_to_loculus.py
@@ -102,9 +102,9 @@ def submit_to_silo(result_dir: Path, s3_link: str) -> bool:
 
     if is_ci_environment():
         logging.info(
-            "Running in CI environment, mocking S3 upload, skipping LAPIS submission."
+            "CI environment active; using mock URLs but executing submission mechanics."
         )
-        # Get mock URLs for CI environment
+        # Get mock URLs for CI environment, then continue with LAPIS submission
         KEYCLOAK_TOKEN_URL, SUBMISSION_URL = get_mock_urls()
     else:
         # Get URLs from environment or use defaults

--- a/src/sr2silo/import_to_loculus.py
+++ b/src/sr2silo/import_to_loculus.py
@@ -9,7 +9,6 @@ import os
 import tempfile
 from pathlib import Path
 
-from memory_profiler import profile
 
 from sr2silo.config import (
     get_keycloak_token_url,
@@ -132,7 +131,6 @@ def submit_to_silo(result_dir: Path, s3_link: str) -> bool:
         return False
 
 
-@profile
 def nuc_align_to_silo_njson(
     input_file: Path,
     sample_id: str,

--- a/src/sr2silo/main.py
+++ b/src/sr2silo/main.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from pathlib import Path
 from typing import Annotated
 
@@ -117,6 +118,14 @@ def import_to_loculus(
     logging.info(f"Using sample_id: {sample_id}")
     logging.info(f"Using batch_id: {batch_id}")
     logging.info(f"Upload to S3 and submit to SILO: {upload}")
+
+    # check if $TMPDIR is set, if not use /tmp
+    if "TMPDIR" in os.environ:
+        temp_dir = Path(os.environ["TMPDIR"])
+        logging.info(f"Recognize temporary directory set in Env: {temp_dir}")
+        logging.info(
+            "This will be used for amino acid translation and alignment - by diamond."
+        )
 
     ci_env = is_ci_environment()
     logging.info(f"Running in CI environment: {ci_env}")

--- a/src/sr2silo/process/__init__.py
+++ b/src/sr2silo/process/__init__.py
@@ -23,7 +23,7 @@ from sr2silo.process.interface import (
 )
 from sr2silo.process.merge import paired_end_read_merger
 from sr2silo.process.translate_align import (
-    enrich_read_with_metadata,
+    curry_read_with_metadata,
     nuc_to_aa_alignment,
     parse_translate_align,
     parse_translate_align_in_batches,
@@ -47,8 +47,8 @@ __all__ = [
     # from sr2silo.process.merge
     "paired_end_read_merger",
     # from sr2silo.process.translate_align
-    "enrich_read_with_metadata",
     "nuc_to_aa_alignment",
     "parse_translate_align",
     "parse_translate_align_in_batches",
+    "curry_read_with_metadata",
 ]

--- a/src/sr2silo/process/convert.py
+++ b/src/sr2silo/process/convert.py
@@ -435,10 +435,7 @@ def sort_and_index_bam(input_bam_fp: Path, output_bam_fp: Path) -> None:
     else:
         # copy the input BAM file to the output BAM file
         output_bam_fp.write_bytes(input_bam_fp.read_bytes())
-        logging.info(
-            "Input BAM file is already sorted and indexed, \
-                      copying to output"
-        )
+        logging.info("Input BAM file is already sorted and indexed, copying to output")
 
 
 def _sort_and_index_bam(input_bam_fp: Path, output_bam_fp: Path) -> None:

--- a/src/sr2silo/process/translate_align.py
+++ b/src/sr2silo/process/translate_align.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Dict, List
 
 import zstandard as zstd
+from memory_profiler import profile
 from tqdm import tqdm
 
 import sr2silo.process.convert as convert
@@ -92,6 +93,7 @@ def translate_nextclade(
             command = ["mv", f"{temp_dir}/results", str(result_path)]
 
 
+@profile
 def nuc_to_aa_alignment(
     in_nuc_alignment_fp: Path,
     in_aa_reference_fp: Path,
@@ -210,6 +212,7 @@ def nuc_to_aa_alignment(
     return None
 
 
+@profile
 def make_read_with_nuc_seq(
     fastq_nuc_alignment_file: Path, nuc_reference_length: int, gene_set: GeneSet
 ) -> Dict[str, AlignedRead]:
@@ -273,6 +276,7 @@ def make_read_with_nuc_seq(
     return aligned_reads
 
 
+@profile
 def enrich_read_with_nuc_ins(
     aligned_reads: dict[str, AlignedRead], fasta_nuc_insertions_file: Path
 ) -> Dict[str, AlignedRead]:
@@ -293,6 +297,7 @@ def enrich_read_with_nuc_ins(
     return aligned_reads
 
 
+@profile
 def enrich_read_with_aa_seq(
     aligned_reads: Dict[str, AlignedRead],
     fasta_aa_alignment_file: Path,
@@ -340,6 +345,7 @@ def enrich_read_with_aa_seq(
     return aligned_reads
 
 
+@profile
 def parse_translate_align(
     nuc_reference_fp: Path, aa_reference_fp: Path, nuc_alignment_fp: Path
 ) -> Dict[str, AlignedRead]:
@@ -398,6 +404,7 @@ def parse_translate_align(
     return aligned_reads
 
 
+@profile
 def enrich_read_with_metadata(
     aligned_reads: Dict[str, AlignedRead],
     metadata_fp: Path,
@@ -426,6 +433,7 @@ def enrich_read_with_metadata(
     return aligned_reads
 
 
+@profile
 def parse_translate_align_in_batches(
     nuc_reference_fp: Path,
     aa_reference_fp: Path,

--- a/src/sr2silo/process/translate_align.py
+++ b/src/sr2silo/process/translate_align.py
@@ -131,7 +131,7 @@ def nuc_to_aa_alignment(
         logging.info("FASTA conversion for AA alignment")
         convert.bam_to_fasta(in_nuc_alignment_fp, fasta_nuc_for_aa_alignment)
 
-        # check if temp_dir is specieifed in the environment
+        # check if temp_dir is specified in the environment
         if "TMPDIR" in os.environ:
             temp_dir_path = Path(os.environ["TMPDIR"])
             logging.info("Recognize temporary directory set in Env: %s", temp_dir_path)

--- a/src/sr2silo/process/translate_align.py
+++ b/src/sr2silo/process/translate_align.py
@@ -134,14 +134,11 @@ def nuc_to_aa_alignment(
         # check if temp_dir is specieifed in the environment
         if "TMPDIR" in os.environ:
             temp_dir_path = Path(os.environ["TMPDIR"])
-            logging.info(f"Recognize temporary directory set in Env: {temp_dir_path}")
-            logging.info(
-                "This will be used for amino acid translation and alignment - by diamond."
-            )
+            logging.info("Recognize temporary directory set in Env: %s", temp_dir_path)
+            logging.info("Used for amino acid translation and alignment - by diamond.")
         else:
-            logging.info(
-                f"Temporary directory not set in Env. Using output dir default: {temp_dir_path}"
-            )
+            logging.info("Temporary directory not set in Env.")
+            logging.info("Using output dir default: %s", temp_dir_path)
 
         logging.info(f"Using temporary directory for diamond: {temp_dir_path}")
 

--- a/src/sr2silo/process/translate_align.py
+++ b/src/sr2silo/process/translate_align.py
@@ -8,7 +8,7 @@ import os
 import subprocess
 import tempfile
 from pathlib import Path
-from typing import Dict, List
+from typing import Callable, Dict, List
 
 import zstandard as zstd
 from memory_profiler import profile
@@ -404,13 +404,12 @@ def parse_translate_align(
     return aligned_reads
 
 
-@profile
-def enrich_read_with_metadata(
-    aligned_reads: Dict[str, AlignedRead],
-    metadata_fp: Path,
-) -> Dict[str, AlignedRead]:
-    """Enrich the AlignedReads with metadata from a TSV file."""
+def curry_read_with_metadata(metadata_fp: Path) -> Callable[[AlignedRead], AlignedRead]:
+    """Returns a function that enriches an AlignedRead with metadata.
 
+    Reads metadata from a JSON file and returns a function that enriches
+    an AlignedRead with the loaded metadata.
+    """
     try:
         with open(metadata_fp, "r") as file:
             metadata = json.load(file)
@@ -424,13 +423,30 @@ def enrich_read_with_metadata(
         logging.error(f"An unexpected error occurred: {e}")
         raise e
 
-    if metadata:
-        for read_id, read in aligned_reads.items():
-            read.metadata = metadata
-    else:
+    if not metadata:
         logging.error("No metadata found in the file")
         raise ValueError("No metadata found in the file")
-    return aligned_reads
+
+    def enrich_single_read(read: AlignedRead) -> AlignedRead:
+        """Enrich a single read with metadata."""
+        read.metadata = metadata
+        return read
+
+    return enrich_single_read
+
+
+@profile
+def process_bam_files(bam_splits_fps, nuc_reference_fp, aa_reference_fp, metadata_fp):
+    """Generator to process BAM files and yield JSON strings."""
+
+    enrich_single_read = curry_read_with_metadata(metadata_fp)
+
+    for bam_split_fp in bam_splits_fps:
+        for read in parse_translate_align(
+            nuc_reference_fp, aa_reference_fp, bam_split_fp
+        ).values():
+            enriched_read = enrich_single_read(read)
+            yield enriched_read.to_silo_json()
 
 
 @profile
@@ -440,8 +456,8 @@ def parse_translate_align_in_batches(
     nuc_alignment_fp: Path,
     metadata_fp: Path,
     output_fp: Path,
-    chunk_size: int = 500000,
-    write_chunk_size: int = 100000,
+    chunk_size: int = 100000,
+    write_chunk_size: int = 20,
 ) -> Path:
     """Parse nucleotides, translate and align amino acids in batches.
 
@@ -459,7 +475,7 @@ def parse_translate_align_in_batches(
 
     Resources:
         A chunk_size of 100000 reads is a good starting point for most cases.
-        This will take about 3.5 GB ram for Covid Genomes and 1-2 minutes to process.
+        This will take about 3.7 GB ram for Covid Genomes and 1-2 minutes to process.
 
     Constraints:
         No sorting constraints are enforced on the input files.
@@ -493,31 +509,22 @@ def parse_translate_align_in_batches(
             # process each batch and write to a ndjson file
             with tqdm(total=len(bam_splits_fps), desc="Processing batches") as pbar:
                 cctx = zstd.ZstdCompressor()
-                with open(output_fp, "wb") as f:
+                with open(output_fp, "wb") as f, cctx.stream_writer(f) as compressor:
                     buffer = []
-                    for i, bam_split_fp in enumerate(bam_splits_fps):
-                        logging.info(f"Processing batch {i+1}")
-                        aligned_reads = parse_translate_align(
-                            nuc_reference_fp=nuc_reference_fp,
-                            aa_reference_fp=aa_reference_fp,
-                            nuc_alignment_fp=bam_split_fp,
-                        )
-                        aligned_reads = enrich_read_with_metadata(
-                            aligned_reads, metadata_fp
-                        )
+                    for json_str in process_bam_files(
+                        bam_splits_fps, nuc_reference_fp, aa_reference_fp, metadata_fp
+                    ):
+                        buffer.append(json_str)
+                        if len(buffer) >= write_chunk_size:
+                            data = ("\n".join(buffer) + "\n").encode("utf-8")
+                            compressor.write(data)
+                            buffer = []
+                            pbar.update(write_chunk_size)  # Update progress per batch
 
-                        for read in aligned_reads.values():
-                            buffer.append(read.to_silo_json())
-                            if len(buffer) >= write_chunk_size:
-                                data = ("\n".join(buffer) + "\n").encode("utf-8")
-                                compressed_data = cctx.compress(data)
-                                f.write(compressed_data)
-                                buffer = []
-                        pbar.update(1)
                     # Write any remaining lines
                     if buffer:
                         data = ("\n".join(buffer) + "\n").encode("utf-8")
-                        compressed_data = cctx.compress(data)
-                        f.write(compressed_data)
+                        compressor.write(data)
+                        pbar.update(len(buffer))
 
     return output_fp

--- a/src/sr2silo/silo/lapis.py
+++ b/src/sr2silo/silo/lapis.py
@@ -28,6 +28,7 @@ class LapisClient:
         if self.is_ci_environment is True:
             logging.info("CI environment detected. Using dummy token.")
             self.token = "dummy_token"
+            return None
 
         response = requests.post(
             self.token_url,

--- a/tests/process/conftest.py
+++ b/tests/process/conftest.py
@@ -31,8 +31,6 @@ def aligned_reads() -> Dict[str, AlignedRead]:
         nuc_ref_fp, aa_ref_fp, nuc_alignment_fp
     )
 
-    from sr2silo.process import enrich_read_with_metadata
-
     # make mock metadata with all empty strings, but readId
     # print emoptry ReadMetadata scehma to json
     metadata = {
@@ -58,6 +56,11 @@ def aligned_reads() -> Dict[str, AlignedRead]:
         json.dump(metadata, f, indent=4)
         metadata_fp = Path(f.name)
 
-    aligned_reads = enrich_read_with_metadata(aligned_reads, metadata_fp)
+    enrich_read_with_metadata = translate_align.curry_read_with_metadata(metadata_fp)
+
+    aligned_reads = {
+        read_id: enrich_read_with_metadata(read)
+        for read_id, read in aligned_reads.items()
+    }
 
     return aligned_reads

--- a/tests/snakemake/test_process_sample.py
+++ b/tests/snakemake/test_process_sample.py
@@ -84,7 +84,12 @@ def test_process_sample():
             "rb",
         ) as f:
             decompressor = zstd.ZstdDecompressor()
-            generated_content = decompressor.decompress(f.read()).decode("utf-8")
+            try:
+                generated_content = decompressor.decompress(f.read()).decode("utf-8")
+            except zstd.ZstdError:
+                f.seek(0)
+                with decompressor.stream_reader(f) as reader:
+                    generated_content = reader.read().decode("utf-8")
 
         with open(expected_path, "rb") as f:
             expected_content = (

--- a/tests/snakemake/test_process_sample.py
+++ b/tests/snakemake/test_process_sample.py
@@ -18,7 +18,6 @@ def test_process_sample():
     """Test the process_sample rule."""
 
     with TemporaryDirectory() as tmpdir:
-
         workdir = Path(tmpdir) / "workdir"
         data_path = Path("tests/snakemake/process_sample/data")
         expected_path = Path(
@@ -37,12 +36,6 @@ def test_process_sample():
 
         # make dir for results
         os.makedirs(workdir / "results", exist_ok=True)
-
-        # dbg
-        print(
-            "results/sampleId-A1_05_2024_10_08_batchId-20241024_2411515907.ndjson.zst",
-            file=sys.stderr,
-        )
 
         # Run the test job.
         try:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+
 from typer.testing import CliRunner
 
 from sr2silo.main import app
@@ -74,7 +76,10 @@ def test_import_to_loculus_with_real_files(real_sample_files_import_to_loculus):
 def test_import_to_loculus_with_real_files_and_upload(
     real_sample_files_import_to_loculus,
 ):
-    """Test import-to-loculus with real sample files and upload flag."""
+    """Test import-to-loculus with real sample files and upload flag in a CI environment."""
+    env = os.environ.copy()
+    env["CI"] = "true"
+
     result = runner.invoke(
         app,
         [
@@ -95,6 +100,7 @@ def test_import_to_loculus_with_real_files_and_upload(
             real_sample_files_import_to_loculus["reference"],
             "--upload",
         ],
+        env=env,
     )
 
     assert result.exit_code == 0

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,3 +1,9 @@
+"""Tests for the main CLI application of sr2silo.
+These tests cover the command-line interface and its
+functionality, ensuring that the application behaves
+as expected when invoked with various commands and options.
+"""
+
 from __future__ import annotations
 
 import os
@@ -76,7 +82,9 @@ def test_import_to_loculus_with_real_files(real_sample_files_import_to_loculus):
 def test_import_to_loculus_with_real_files_and_upload(
     real_sample_files_import_to_loculus,
 ):
-    """Test import-to-loculus with real sample files and upload flag in a CI environment."""
+    """Test import-to-loculus with real sample files and upload flag in a CI
+    environment.
+    """
     env = os.environ.copy()
     env["CI"] = "true"
 

--- a/workflow/README.md
+++ b/workflow/README.md
@@ -3,3 +3,5 @@
 This directory contains some workflows implemented in `snakemake` to enable,
 rapid historical data conversion and import to JSON like format, ready for
 import in SILO.
+
+**Note:** Please check the documentation for information on resource requirements when running sr2silo, especially in cluster environments.

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -3,6 +3,8 @@
 """
 
 import yaml
+import os
+from pathlib import Path
 
 
 configfile: "workflow/config.yaml"
@@ -11,6 +13,13 @@ configfile: "workflow/config.yaml"
 # Load configuration
 with open("workflow/config.yaml", "r") as file:
     config = yaml.safe_load(file)
+
+
+# Check for TMPDIR environment variable
+temp_dir = None
+if "TMPDIR" in os.environ:
+    temp_dir = Path(os.environ["TMPDIR"])
+    print(f"Using TMPDIR environment variable: {temp_dir}")
 
 
 def get_batch_id(sample_id):
@@ -46,11 +55,13 @@ rule process_sample:
         primers_file=config["PRIMERS_FILE"],
         nuc_reference=config["NUC_REFERENCE"],
         aa_reference=config["NUC_REFERENCE"],
+        temp_dir=temp_dir,
     log:
         "logs/sr2silo/process_sample/sampleId_{sample_id}_batchId_{batch_id}.log",  # Clearer wildcard separation
     shell:
         """
         echo "Processing sample {params.sample_id} started" >> {log}
+        {{"TMPDIR=" + str(params.temp_dir) if params.temp_dir else ""}} \
         sr2silo import-to-loculus \
             --input-file {input.sample_fp} \
             --sample-id {params.sample_id} \

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -8,7 +8,7 @@ from pathlib import Path
 
 
 #CONFIG="workflow/config.yaml"
-CONFIG="workflow/config_euler.yaml"
+CONFIG="workflow/config.yaml"
 
 
 configfile: CONFIG
@@ -16,13 +16,6 @@ configfile: CONFIG
 # Load configuration
 with open(CONFIG, "r") as file:
     config = yaml.safe_load(file)
-
-
-# Check for TMPDIR environment variable
-temp_dir = None
-if "TMPDIR" in os.environ:
-    temp_dir = Path(os.environ["TMPDIR"])
-    print(f"Using TMPDIR environment variable: {temp_dir}")
 
 
 def get_batch_id(sample_id):
@@ -58,13 +51,10 @@ rule process_sample:
         primers_file=config["PRIMERS_FILE"],
         nuc_reference=config["NUC_REFERENCE"],
         aa_reference=config["NUC_REFERENCE"],
-        temp_dir=temp_dir,
     log:
         "logs/sr2silo/process_sample/sampleId_{sample_id}_batchId_{batch_id}.log",  # Clearer wildcard separation
     shell:
         """
-        echo "Processing sample {params.sample_id} started" >> {log}
-        {{"TMPDIR=" + str(params.temp_dir) if params.temp_dir else ""}} \
         sr2silo import-to-loculus \
             --input-file {input.sample_fp} \
             --sample-id {params.sample_id} \
@@ -74,5 +64,4 @@ rule process_sample:
             --output-fp {output.result_fp} \
             --reference {params.nuc_reference} \
             --no-upload 2>&1 | tee -a {log}
-        echo "Processing sample {params.sample_id} completed" >> {log}
         """

--- a/workflow/config.yaml
+++ b/workflow/config.yaml
@@ -2,6 +2,6 @@ BASE_SAMPLE_DIR: "tests/data/samples_large"
 SAMPLE_BATCH_IDS:
   A1_05_2024_10_08: "20241024_2411515907"
 TIMELINE_FILE: "tests/data/samples_large/timeline_A1_05_2024_10_08.tsv"
-PRIMERS_FILE: "tests/data/samples_large/primers.yaml"
+PRIMERS_FILE: "resources/sars-cov-2/primers/primers.yaml"
 NUC_REFERENCE: "sars-cov-2"
 RESULTS_DIR: "results"

--- a/workflow/config_euler.yaml
+++ b/workflow/config_euler.yaml
@@ -1,4 +1,4 @@
-BASE_SAMPLE_DIR: "tests/data/samples"
+BASE_SAMPLE_DIR: "/cluster/project/pangolin/gordon_samples/samples"
 SAMPLE_BATCH_IDS:
   A1_05_2024_10_08: "20241024_2411515907"
   A2_17_2024_10_13: "20241024_2411515907"
@@ -27,4 +27,4 @@ SAMPLE_BATCH_IDS:
 TIMELINE_FILE: "/cluster/project/pangolin/work-vp-test/variants/timeline.tsv"
 PRIMERS_FILE: "/cluster/project/pangolin/work-new-variants/references/primers.yaml"
 NUC_REFERENCE: "sars-cov-2"
-RESULTS_DIR: "results"
+RESULTS_DIR: "/cluster/project/pangolin/gordon_samples/temp_test"

--- a/workflow/submit_workflow.sh
+++ b/workflow/submit_workflow.sh
@@ -2,9 +2,10 @@
 sbatch \
     --mail-type=END \
     --ntasks=1 \
-    --cpus-per-task=24 \
-    --mem-per-cpu=32000 \
+    --cpus-per-task=4 \
+    --mem-per-cpu=8G \
+    --tmp=160G \
     --time=2:00:00 \
     -o /cluster/home/koehng/logs/sr2silo.out \
     -e /cluster/home/koehng/logs/sr2silo.err \
-    snakemake -c 24
+    snakemake -c 4


### PR DESCRIPTION
It turns out that the amino acid alignment with `diamond` requires a significant amount of temporary directory space.  

For the batched processing of 100,000 reads, which leads to 3.7 GB of RAM usage in Python and approximately another 3 GB from `diamond`, about 30-40 GB of temporary directory space is utilized for each amino acid alignment batch.  

This is expected and is documented in the `diamond` documentation.  

On most personal machines, this will be manageable, but this PR implements the option to specify this temporary directory space. Otherwise, jobs may be terminated in cluster settings.  

This PR thus clarifies and reduces the resource usage of the entire processing to:  
- 8 GB RAM  
- 40 GB temporary directory (ideally high I/O)  
- 1 CPU  

Runtime: ~1:30 h 