### PR TITLE
docs: update readme with changes skipped chars for amino acids

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ sr2silo outputs per read a JSON (mock output):
     "alignedAminoAcidSequences":{
                 "E":"",
                 ...
-                "ORF1a":"...NMESLVPGFNEKTHVQLSLPVLQVRVRGFGDSVEEVLSEARQHLKDGTCGLVEVEKGVNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN...",
+                "ORF1a":"...XXXMESLVPGFNEKTHVQLSLPVLQVRVRGFGDSVEEVLSEARQHLKDGTCGLVEVEKGVXXXXXX...",
                 ...
                 "S":""}
       }


### PR DESCRIPTION
The correction 
- #200 

requires a correction in the docs.