### PR TITLE
Bump smallgenomeutilities v0.5.1

### DIFF
--- a/environments/dev-environment.yml
+++ b/environments/dev-environment.yml
@@ -8,4 +8,4 @@ dependencies:
   - poetry>=1.8.3
   - diamond>=2.1.0
   - snakemake=8.18  # fixed as snakemake unit tests fail with 8.19
-  - smallgenomeutilities>=0.5.0
+  - smallgenomeutilities>=0.5.1

--- a/environments/environment.yml
+++ b/environments/environment.yml
@@ -7,4 +7,4 @@ dependencies:
   - python>=3.11
   - poetry>=1.8.3
   - diamond>=2.1.0
-  - smallgenomeutilities>=0.5.0
+  - smallgenomeutilities>=0.5.1

--- a/environments/workflow-environment.yml
+++ b/environments/workflow-environment.yml
@@ -7,4 +7,4 @@ dependencies:
   - python>=3.11
   - snakemake=8.18  # fixed as snakemake unit tests fail with 8.19
   - diamond>=2.1.0
-  - smallgenomeutilities>=0.5.0
+  - smallgenomeutilities>=0.5.1


### PR DESCRIPTION
A new version of `smallgenomeutilities` changes the default behaviour of the `paired_read_merging`.

Unpaired reads are now by default keep and written to the same output file. 

This means `sr2silo` implements them.