### PR TITLE
Adding Copilot Config

### DIFF
--- a/.github/copilot.yml
+++ b/.github/copilot.yml
@@ -1,0 +1,2 @@
+agent:
+  default_branch: dev


### PR DESCRIPTION
This PR adds a config for the Copilot agent to work by default on the dev branch.