### PR TITLE
Refactor:  sample id removed from submit_to_loculus cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,82 +176,34 @@ conda activate sr2silo-dev
 pytest
 ```
 
-### Run CLI
-
-The sr2silo CLI has three main commands:
-
-1. `run` - Not yet implemented command for future functionality
-2. `process-from-vpipe` - Process V-Pipe BAM alignments to SILO format (processing only)
-3. `submit-to-loculus` - Upload processed files to S3 and submit to SILO/Loculus
-
-#### Two-Step Workflow
+### Usage
 
 sr2silo follows a two-step workflow:
 
-**Step 1: Process V-Pipe data**
+1. **Process data:** `sr2silo process-from-vpipe --help`
+2. **Submit to Loculus:** `sr2silo submit-to-loculus --help`
+
 ```bash
+# Example: Process V-Pipe data
 sr2silo process-from-vpipe \
-    --input-file INPUT.bam \
-    --sample-id SAMPLE_ID \
-    --batch-id BATCH_ID \
-    --timeline-file TIMELINE.tsv \
-    --primer-file PRIMERS.yaml \
-    --output-fp OUTPUT.ndjson \
-    --reference sars-cov-2
+    --input-file input.bam \
+    --sample-id SAMPLE_001 \
+    --batch-id BATCH_001 \
+    --timeline-file timeline.tsv \
+    --primer-file primers.yaml \
+    --output-fp output.ndjson
+
+# Example: Submit to Loculus (use environment variables for credentials)
+export KEYCLOAK_TOKEN_URL=https://auth.example.com/token
+export SUBMISSION_URL=https://api.example.com/submit
+export GROUP_ID=123
+export USERNAME=your-username
+export PASSWORD=your-password
+
+sr2silo submit-to-loculus --processed-file output.ndjson.zst
 ```
 
-**Step 2: Submit to Loculus**
-```bash
-sr2silo submit-to-loculus \
-    --processed-file OUTPUT.ndjson.zst \
-    --sample-id SAMPLE_ID
-```
-
-#### Required Arguments for `process-from-vpipe`
-
-- `--input-file, -i`: Path to the input BAM alignment file
-- `--sample-id, -s`: Sample ID to use for metadata
-- `--batch-id, -b`: Batch ID to use for metadata
-- `--timeline-file, -t`: Path to the timeline metadata file
-- `--primer-file, -p`: Path to the primers configuration file
-- `--output-fp, -o`: Path for the output file (will be auto-suffixed with .ndjson.zst)
-
-#### Required Arguments for `submit-to-loculus`
-
-- `--processed-file, -f`: Path to the processed .ndjson.zst file to upload and submit
-- `--sample-id, -s`: Sample ID for the processed file
-
-#### Optional Arguments for `process-from-vpipe`
-
-- `--reference, -r`: Reference genome to use (default: "sars-cov-2")
-- `--skip-merge/--no-skip-merge`: Skip merging of paired-end reads (default: no-skip-merge)
-
-#### Example Usage
-
-Here's a complete example with sample data:
-
-**Step 1: Process V-Pipe data**
-```bash
-sr2silo process-from-vpipe \
-    --input-file ./data/sample/alignments/REF_aln_trim.bam \
-    --sample-id "A1_05_2024_10_08" \
-    --batch-id "20241024_2411515907" \
-    --timeline-file ./data/timeline.tsv \
-    --primer-file ./data/primers.yaml \
-    --output-fp ./results/output.ndjson \
-    --reference sars-cov-2
-```
-
-This will create a processed file `./results/output.ndjson.zst`.
-
-**Step 2: Submit to Loculus**
-```bash
-sr2silo submit-to-loculus \
-    --processed-file ./results/output.ndjson.zst \
-    --sample-id "A1_05_2024_10_08"
-```
-
-This will upload the processed file to S3 and submit it to SILO/Loculus.
+**Note:** Use environment variables for credentials to avoid exposing sensitive information in command history.
 
 ### Environment Variable Configuration
 
@@ -261,28 +213,32 @@ sr2silo supports flexible configuration through environment variables, making it
 - No `.env` file required
 - CLI parameters override environment variables
 - Environment variables provide convenient defaults
+- **Recommended for credentials to avoid exposing sensitive information in command history**
 
-**Quick example using environment variables:**
+**Common configuration via environment variables:**
 ```bash
-# Set common configuration via environment variables
-export TIMELINE_FILE=/path/to/timeline.tsv
-export PRIMER_FILE=/path/to/primers.yaml
+# Optional configuration (can also be provided via CLI)
 export NEXTCLADE_REFERENCE=sars-cov-2
 
-# Run with minimal CLI arguments
+# Authentication credentials (recommended approach for security)
+export KEYCLOAK_TOKEN_URL=https://auth.example.com/token
+export SUBMISSION_URL=https://backend.example.com/api
+export GROUP_ID=123
+export USERNAME=your-username
+export PASSWORD=your-password
+
+# Run with required CLI arguments (timeline and primer files must be specified)
 sr2silo process-from-vpipe \
     --input-file input.bam \
     --sample-id SAMPLE_001 \
     --batch-id BATCH_001 \
+    --timeline-file /path/to/timeline.tsv \
+    --primer-file /path/to/primers.yaml \
     --output-fp output.ndjson
 
-# Environment variables for submission
-export KEYCLOAK_TOKEN_URL=https://auth.example.com/token
-export SUBMISSION_URL=https://backend.example.com/api
-
+# Submission using environment variables for credentials
 sr2silo submit-to-loculus \
-    --processed-file output.ndjson.zst \
-    --sample-id SAMPLE_001
+    --processed-file output.ndjson.zst
 ```
 
 For complete documentation on environment variable configuration, see [docs/usage/environment_configuration.md](docs/usage/environment_configuration.md).

--- a/src/sr2silo/config.py
+++ b/src/sr2silo/config.py
@@ -150,18 +150,6 @@ def get_primer_file(default: Path | str | None = None) -> Path | None:
     return None
 
 
-def get_nextclade_reference(default: str = "sars-cov-2") -> str:
-    """Get the Nextclade reference from environment, or return default if not set.
-
-    Args:
-        default: Default reference to use if environment variable is not set
-
-    Returns:
-        str: The Nextclade reference identifier
-    """
-    return os.getenv("NEXTCLADE_REFERENCE", default)
-
-
 def get_group_id(default: int | None = None) -> int:
     """Get the group ID from environment, or return default if not set.
 

--- a/src/sr2silo/main.py
+++ b/src/sr2silo/main.py
@@ -12,11 +12,8 @@ import typer
 from sr2silo.config import (
     get_group_id,
     get_keycloak_token_url,
-    get_nextclade_reference,
     get_password,
-    get_primer_file,
     get_submission_url,
-    get_timeline_file,
     get_username,
     get_version,
     is_ci_environment,
@@ -45,15 +42,6 @@ def callback(ctx: typer.Context):
     """Callback function that runs when no subcommand is provided."""
     if ctx.invoked_subcommand is None:
         typer.echo("Well, you gotta decide what to do.. see --help for subcommands")
-
-
-@app.command()
-def run():
-    """
-    Wrangel short-reads into cleartext alignments,
-    optionally translation and align in amino acids.
-    """
-    typer.echo("Not yet implemented.")
 
 
 @app.command()
@@ -91,32 +79,29 @@ def process_from_vpipe(
         ),
     ],
     timeline_file: Annotated[
-        Path | None,
+        Path,
         typer.Option(
             "--timeline-file",
             "-t",
-            help="Path to the timeline file. Falls back to TIMELINE_FILE "
-            "environment variable.",
+            help="Path to the timeline file.",
         ),
-    ] = None,
+    ],
     primer_file: Annotated[
-        Path | None,
+        Path,
         typer.Option(
             "--primer-file",
             "-p",
-            help="Path to the primers file. Falls back to PRIMER_FILE "
-            "environment variable.",
+            help="Path to the primers file.",
         ),
-    ] = None,
+    ],
     reference: Annotated[
-        str | None,
+        str,
         typer.Option(
             "--reference",
             "-r",
-            help="See folder names in resources/. Falls back to "
-            "NEXTCLADE_REFERENCE environment variable.",
+            help="See folder names in resources/.",
         ),
-    ] = None,
+    ],
     skip_merge: Annotated[
         bool,
         typer.Option(
@@ -130,30 +115,6 @@ def process_from_vpipe(
     Processing only - use 'submit-to-loculus' command to upload and submit to SILO.
     """
     typer.echo("Starting V-PIPE to SILO conversion.")
-
-    # Resolve timeline_file with environment fallback
-    if timeline_file is None:
-        timeline_file = get_timeline_file()
-        if timeline_file is None:
-            logging.error(
-                "Timeline file must be provided via --timeline-file "
-                "or TIMELINE_FILE environment variable"
-            )
-            raise typer.Exit(1)
-
-    # Resolve primer_file with environment fallback
-    if primer_file is None:
-        primer_file = get_primer_file()
-        if primer_file is None:
-            logging.error(
-                "Primer file must be provided via --primer-file or "
-                "PRIMER_FILE environment variable"
-            )
-            raise typer.Exit(1)
-
-    # Resolve reference with environment fallback
-    if reference is None:
-        reference = get_nextclade_reference()
 
     logging.info(f"Processing input file: {input_file}")
     logging.info(f"Using timeline file: {timeline_file}")
@@ -202,14 +163,6 @@ def submit_to_loculus(
             "--processed-file",
             "-f",
             help="Path to the processed .ndjson.zst file to upload and submit.",
-        ),
-    ],
-    sample_id: Annotated[
-        str,
-        typer.Option(
-            "--sample-id",
-            "-s",
-            help="Sample ID for the processed file.",
         ),
     ],
     keycloak_token_url: Annotated[
@@ -279,7 +232,6 @@ def submit_to_loculus(
         password = get_password()
 
     logging.info(f"Processing file: {processed_file}")
-    logging.info(f"Using sample_id: {sample_id}")
     logging.info(f"Using Keycloak token URL: {keycloak_token_url}")
     logging.info(f"Using submission URL: {submission_url}")
     logging.info(f"Using group ID: {group_id}")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,7 +11,6 @@ from unittest.mock import patch
 
 from sr2silo.config import (
     get_keycloak_token_url,
-    get_nextclade_reference,
     get_primer_file,
     get_submission_url,
     get_timeline_file,
@@ -141,24 +140,6 @@ def test_get_primer_file():
     with patch.dict(os.environ, {}, clear=True):
         result = get_primer_file()
         assert result is None
-
-
-def test_get_nextclade_reference():
-    """Test get_nextclade_reference function."""
-    # Test with environment variable set
-    with patch.dict(os.environ, {"NEXTCLADE_REFERENCE": "custom-ref"}):
-        result = get_nextclade_reference()
-        assert result == "custom-ref"
-
-    # Test with environment variable not set, uses default
-    with patch.dict(os.environ, {}, clear=True):
-        result = get_nextclade_reference()
-        assert result == "sars-cov-2"
-
-    # Test with custom default
-    with patch.dict(os.environ, {}, clear=True):
-        result = get_nextclade_reference("custom-default")
-        assert result == "custom-default"
 
 
 def test_get_keycloak_token_url():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -111,8 +111,6 @@ def test_submit_to_loculus_command_wrong_extension():
                 "submit-to-loculus",
                 "--processed-file",
                 tmp_path,
-                "--sample-id",
-                "test_sample",
             ],
         )
         assert result.exit_code == 1
@@ -176,11 +174,13 @@ def test_process_from_vpipe_environment_variables():
                 "test-batch",
                 "--output-fp",
                 "/tmp/test.ndjson.zst",
+                "--reference",
+                "sars-cov-2",
             ],
         )
         # Should fail due to missing input file,
         # but environment variables should be processed
-        assert result.exit_code == 1  # Should fail due to missing file
+        assert result.exit_code == 2  # Should fail due to missing file
         # We can verify the environment variables were picked up by manually checking
         # since the logs go to stderr which typer doesn't capture by default
 
@@ -242,6 +242,12 @@ def test_process_from_vpipe_missing_env_and_cli():
                 "test-batch",
                 "--output-fp",
                 "/tmp/test.ndjson.zst",
+                "--reference",
+                "sars-cov-2",
+                "--primer-file",
+                "/tmp/primers.yaml",
+                "--timeline-file",
+                "/tmp/timeline.tsv",
             ],
         )
         assert result.exit_code == 1

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -28,13 +28,6 @@ def test_no_args():
     assert "Well, you gotta decide what to do" in result.stdout
 
 
-def test_run_command():
-    """Test the run subcommand."""
-    result = runner.invoke(app, ["run"])
-    assert result.exit_code == 0
-    assert "Not yet implemented" in result.stdout
-
-
 def test_process_from_vpipe_help():
     """Test the help output for process-from-vpipe command."""
     result = runner.invoke(app, ["process-from-vpipe", "--help"])
@@ -97,8 +90,6 @@ def test_submit_to_loculus_command_nonexistent_file():
             "submit-to-loculus",
             "--processed-file",
             "/tmp/nonexistent.ndjson.zst",
-            "--sample-id",
-            "test_sample",
         ],
     )
     assert result.exit_code == 1
@@ -276,8 +267,6 @@ def test_submit_to_loculus_environment_variables():
                 "submit-to-loculus",
                 "--processed-file",
                 "/tmp/test.ndjson.zst",
-                "--sample-id",
-                "test-sample",
             ],
         )
         # Should fail due to missing file, but environment variables should be processed
@@ -302,8 +291,6 @@ def test_submit_to_loculus_cli_overrides_env():
                 "submit-to-loculus",
                 "--processed-file",
                 "/tmp/test.ndjson.zst",
-                "--sample-id",
-                "test-sample",
                 "--keycloak-token-url",
                 "https://cli.auth.com/token",
                 "--submission-url",
@@ -327,8 +314,6 @@ def test_submit_to_loculus_missing_env_and_cli():
                 "submit-to-loculus",
                 "--processed-file",
                 "/tmp/test.ndjson.zst",
-                "--sample-id",
-                "test-sample",
             ],
         )
         assert result.exit_code == 1

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -194,12 +194,11 @@ rule submit_to_loculus:
     output:
         flag=f"{config['RESULTS_DIR']}/uploads/sampleId-{{sample_id}}_batchId-{{batch_id}}.uploaded",
     params:
-        sample_id=lambda wildcards: wildcards.sample_id,
         keycloak_url=config.get("KEYCLOAK_TOKEN_URL", ""),
         submission_url=config.get("SUBMISSION_URL", ""),
-        group_id=config.get("GROUP_ID", "1"),
-        username=config.get("USERNAME", "testuser"),
-        password=config.get("PASSWORD", "testuser"),
+        group_id=config.get("GROUP_ID", ""),
+        username=config.get("USERNAME", ""),
+        password=config.get("PASSWORD", ""),
     log:
         "logs/sr2silo/submit_to_loculus/sampleId_{sample_id}_batchId_{batch_id}.log",
     conda:
@@ -208,7 +207,6 @@ rule submit_to_loculus:
         """
         sr2silo submit-to-loculus \
             --processed-file {input.result_fp} \
-            --sample-id {params.sample_id} \
             --keycloak-token-url "{params.keycloak_url}" \
             --submission-url "{params.submission_url}" \
             --group-id {params.group_id} \


### PR DESCRIPTION
The CLI has unnecessary arguments in the submit_to_loculus command, which I initially thought would be needed, because of snakemake, but they don't.


This PR refactors the CLI for the submit_to_loculus command by removing the unnecessary sample id argument and cleaning up associated configuration and tests. Key changes include:

- Removing the sample id parameter from the CLI and its associated logging and configuration.
- Dropping the get_nextclade_reference function from config and its tests.
- Adjusting the required parameters for process_from_vpipe and updating the usage documentation in README.md.