### PR TITLE
fix: lapis-url optional

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,20 @@
+# Sample processing configuration
 SAMPLE_DIR=./../../../data/sr2silo/demo_real/A1_10_2024_09_30/20241018_AAG55WNM5/alignments/subsamples/1000/
 SAMPLE_ID=A1_10_2024_09_30
 BATCH_ID=20241018_AAG55WNM5
 TIMELINE_FILE=./../../../data/sr2silo/demo_real/timeline.tsv
 RESULTS_DIR=./../results/A1_10_2024_09_30/20241018_AAG55WNM5/1000/
+
+# Reference genome configuration (optional)
+# If not provided, uses default SARS-CoV-2 references (NCBI Reference Sequence: NC_045512.2)
+# LAPIS_URL=https://lapis.cov-spectrum.org/open/v2
+
+# Loculus authentication and submission
 KEYCLOAK_TOKEN_URL=https://authentication-wise-seqs.loculus.org/realms/loculus/protocol/openid-connect/token
 SUBMISSION_URL=https://backend-wise-seqs.loculus.org/test/submit?groupId={group_id}&dataUseTermsType=OPEN
 GROUP_ID=a
 USERNAME=testuser
 PASSWORD=testpassword
+
+# Environment configuration
 CI=False

--- a/README.md
+++ b/README.md
@@ -198,6 +198,13 @@ sr2silo process-from-vpipe \
     --input-file input.bam \
     --sample-id SAMPLE_001 \
     --timeline-file timeline.tsv \
+    --output-fp output.ndjson
+
+# Example: Process V-Pipe data with custom LAPIS server
+sr2silo process-from-vpipe \
+    --input-file input.bam \
+    --sample-id SAMPLE_001 \
+    --timeline-file timeline.tsv \
     --lapis-url https://lapis.cov-spectrum.org/open/v2 \
     --output-fp output.ndjson
 
@@ -212,6 +219,38 @@ sr2silo submit-to-loculus --processed-file output.ndjson.zst
 ```
 
 **Note:** Use environment variables for credentials to avoid exposing sensitive information in command history.
+
+### Reference Genome Configuration
+
+sr2silo supports flexible reference genome configuration:
+
+**Default Behavior (Recommended):**
+- If no `--lapis-url` is provided, sr2silo uses built-in SARS-CoV-2 references
+- References: NCBI Reference Sequence NC_045512.2 from `resources/references/sars-cov-2/`
+- This ensures consistent, reliable processing without external dependencies
+
+**Custom LAPIS Server:**
+- Provide `--lapis-url` to fetch references from a custom LAPIS instance
+- If the LAPIS server is unavailable, sr2silo automatically falls back to default SARS-CoV-2 references
+- Useful for processing data with organism-specific or updated reference genomes
+
+**Examples:**
+```bash
+# Use default SARS-CoV-2 references (recommended for most use cases)
+sr2silo process-from-vpipe \
+    --input-file input.bam \
+    --sample-id SAMPLE_001 \
+    --timeline-file timeline.tsv \
+    --output-fp output.ndjson
+
+# Use custom LAPIS server with automatic fallback
+sr2silo process-from-vpipe \
+    --input-file input.bam \
+    --sample-id SAMPLE_001 \
+    --timeline-file timeline.tsv \
+    --lapis-url https://lapis.cov-spectrum.org/open/v2 \
+    --output-fp output.ndjson
+```
 
 ### Environment Variable Configuration
 
@@ -231,6 +270,13 @@ export USERNAME=your-username
 export PASSWORD=your-password
 
 # Run with required CLI arguments (timeline file must be specified)
+sr2silo process-from-vpipe \
+    --input-file input.bam \
+    --sample-id SAMPLE_001 \
+    --timeline-file /path/to/timeline.tsv \
+    --output-fp output.ndjson
+
+# Or optionally specify a custom LAPIS server for references
 sr2silo process-from-vpipe \
     --input-file input.bam \
     --sample-id SAMPLE_001 \

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -6,16 +6,27 @@ INPUT_FILE="tests/data/samples_large/A1_05_2024_10_08/20241024_2411515907/alignm
 SAMPLE_ID="A1_05_2024_10_08"
 OUTPUT_FILE="./results_neo/silo_input.ndjson"
 TIMELINE_FILE="tests/data/samples_large/timeline_A1_05_2024_10_08.tsv"
+# Optional: specify LAPIS URL for custom reference genomes
+# If not provided, uses default SARS-CoV-2 references (NCBI Reference Sequence: NC_045512.2)
 LAPIS_URL="https://lapis.cov-spectrum.org/open/v2"
 
 # Run using sr2silo CLI
 # Use submit-to-loculus command to upload and submit processed files to SILO
+
+# Example 1: Use custom LAPIS server for references
 sr2silo process-from-vpipe \
     --input-file "$INPUT_FILE" \
     --sample-id "$SAMPLE_ID" \
     --timeline-file "$TIMELINE_FILE" \
     --lapis-url "$LAPIS_URL" \
     --output-fp "$OUTPUT_FILE"
+
+# Example 2: Use default SARS-CoV-2 references (recommended for most use cases)
+# sr2silo process-from-vpipe \
+#     --input-file "$INPUT_FILE" \
+#     --sample-id "$SAMPLE_ID" \
+#     --timeline-file "$TIMELINE_FILE" \
+#     --output-fp "$OUTPUT_FILE"
 
 # Uncomment the following lines to upload and submit the processed file to SILO
 sr2silo submit-to-loculus \

--- a/src/sr2silo/main.py
+++ b/src/sr2silo/main.py
@@ -24,10 +24,68 @@ from sr2silo.loculus.lapis import LapisClient
 from sr2silo.process_from_vpipe import nuc_align_to_silo_njson
 from sr2silo.submit_to_loculus import submit_to_silo
 
-# Use force=True to override any existing logging configuration
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s", force=True
 )
+
+
+def _get_reference_files(ci_env: bool, lapis_url: str | None) -> tuple[Path, Path]:
+    """Get reference files, either from Lapis or fallback to default CI references.
+
+    Args:
+        ci_env: Whether running in CI environment
+        lapis_url: URL of LAPIS instance, or None to use default references
+
+    Returns:
+        Tuple of (nucleotide_ref_path, amino_acid_ref_path)
+    """
+    # Default SARS-CoV-2 references (NCBI Reference Sequence: NC_045512.2)
+    default_nuc_ref_fp = Path("resources/references/sars-cov-2/nuc_ref.fasta")
+    default_aa_ref_fp = Path("resources/references/sars-cov-2/aa_ref.fasta")
+
+    if ci_env or lapis_url is None:
+        if ci_env:
+            logging.info(
+                "Running in CI environment, using default SARS-CoV-2 references "
+                "from resources/references/sars-cov-2/ (NCBI Reference Sequence: NC_045512.2)"
+            )
+        else:
+            logging.info(
+                "No LAPIS URL provided, using default SARS-CoV-2 references "
+                "from resources/references/sars-cov-2/ (NCBI Reference Sequence: NC_045512.2)"
+            )
+        return default_nuc_ref_fp, default_aa_ref_fp
+
+    # Try to fetch references from Lapis
+    try:
+        lapis = LapisClient(lapis_url)
+        logging.info("Fetching references from Lapis...")
+        reference = lapis.referenceGenome()
+
+        # Create domain-specific directory for Lapis references
+        domain = lapis_url.split("//")[-1].split("/")[0]
+        Path(f"resources/references/{domain}").mkdir(parents=True, exist_ok=True)
+
+        nuc_ref_fp = Path(f"resources/references/{domain}/nuc_ref.fasta")
+        aa_ref_fp = Path(f"resources/references/{domain}/aa_ref.fasta")
+
+        lapis.referenceGenomeToFasta(
+            reference_json_string=json.dumps(reference),
+            nucleotide_out_fp=nuc_ref_fp,
+            amino_acid_out_fp=aa_ref_fp,
+        )
+        logging.info(
+            f"Successfully fetched references from Lapis: {nuc_ref_fp} and {aa_ref_fp}"
+        )
+        return nuc_ref_fp, aa_ref_fp
+
+    except Exception as e:
+        logging.warning(f"Failed to fetch references from Lapis ({lapis_url}): {e}")
+        logging.warning(
+            "Falling back to default SARS-CoV-2 references "
+            "from resources/references/sars-cov-2/ (NCBI Reference Sequence: NC_045512.2)"
+        )
+        return default_nuc_ref_fp, default_aa_ref_fp
 
 
 app = typer.Typer(
@@ -82,14 +140,16 @@ def process_from_vpipe(
         ),
     ],
     lapis_url: Annotated[
-        str,
+        str | None,
         typer.Option(
             "--lapis-url",
             "-r",
-            help="URL of LAPIS instance, hosting SILO database."
-            "Used to fetch the nucleotide / amino acid reference.",
+            help="URL of LAPIS instance, hosting SILO database. "
+            "Used to fetch the nucleotide / amino acid reference. "
+            "If not provided, uses default SARS-CoV-2 references "
+            "(NCBI Reference Sequence: NC_045512.2).",
         ),
-    ],
+    ] = None,
     skip_merge: Annotated[
         bool,
         typer.Option(
@@ -117,7 +177,10 @@ def process_from_vpipe(
     logging.info(f"Processing input file: {input_file}")
     logging.info(f"Using timeline file: {timeline_file}")
     logging.info(f"Using output file: {output_fp}")
-    logging.info(f"Using Lapis URL: {lapis_url}")
+    if lapis_url:
+        logging.info(f"Using Lapis URL: {lapis_url}")
+    else:
+        logging.info("Using default SARS-CoV-2 references (no Lapis URL provided)")
     logging.info(f"Using sample_id: {sample_id}")
     logging.info(f"Skip read pair merging: {skip_merge}")
 
@@ -138,34 +201,8 @@ def process_from_vpipe(
 
     logging.info(f"Running version: {version_info}")
 
-    # if not CI envrionement, get the nucleotide and amino acid references, from Lapis
-    if not ci_env:
-        # make LapisClient
-        lapis = LapisClient(lapis_url)
-        # fetch references
-        reference = lapis.referenceGenome()
-        # convert references to FASTA files
-        logging.info("Fetching references from Lapis...")
-        # get the domain from the lapis_url
-        domain = lapis_url.split("//")[-1].split("/")[0]
-        # create the directory if it does not exist
-        Path(f"resources/references/{domain}").mkdir(parents=True, exist_ok=True)
-        # define the paths for the nucleotide and amino acid references
-        nuc_ref_fp = Path(f"resources/references/{domain}/nuc_ref.fasta")
-        aa_ref_fp = Path(f"resources/references/{domain}/aa_ref.fasta")
-        lapis.referenceGenomeToFasta(
-            reference_json_string=json.dumps(reference),
-            nucleotide_out_fp=nuc_ref_fp,
-            amino_acid_out_fp=aa_ref_fp,
-        )
-        logging.info(f"Fetched references from Lapis: {nuc_ref_fp} and {aa_ref_fp}")
-    else:
-        logging.info(
-            "Running in CI environment, using default references \
-            from resources/references/sars-cov-2/"
-        )
-        nuc_ref_fp = Path("resources/references/sars-cov-2/nuc_ref.fasta")
-        aa_ref_fp = Path("resources/references/sars-cov-2/aa_ref.fasta")
+    # Get nucleotide and amino acid references
+    nuc_ref_fp, aa_ref_fp = _get_reference_files(ci_env, lapis_url)
 
     nuc_align_to_silo_njson(
         input_file=input_file,

--- a/tests/snakemake/process_sample/config.yaml
+++ b/tests/snakemake/process_sample/config.yaml
@@ -4,5 +4,6 @@ LOCATIONS:
 START_DATE: "2024-10-01"
 END_DATE: "2024-10-31"
 TIMELINE_FILE: "timeline_A1_05_2024_10_08.tsv"
+# Optional: LAPIS URL for custom reference genomes (falls back to SARS-CoV-2 defaults if unavailable)
 LAPIS_URL: "https://lapis.example.com"
 RESULTS_DIR: "results"

--- a/tests/snakemake/submit_to_loculus/config.yaml
+++ b/tests/snakemake/submit_to_loculus/config.yaml
@@ -4,6 +4,7 @@ LOCATIONS:
 START_DATE: "2024-10-01"
 END_DATE: "2024-10-31"
 TIMELINE_FILE: "timeline_A1_05_2024_10_08.tsv"
+# Optional: LAPIS URL for custom reference genomes (falls back to SARS-CoV-2 defaults if unavailable)
 LAPIS_URL: "https://lapis.cov-spectrum.org/open/v2"
 RESULTS_DIR: "results"
 

--- a/workflow/config.yaml
+++ b/workflow/config.yaml
@@ -13,7 +13,7 @@ END_DATE: "2025-07-15"
 
 ### Input Files
 BASE_SAMPLE_DIR:  "../results" # "tests/data/samples_large"
-TIMELINE_FILE: "../../work-vp-test/variants/timeline.tsv" # "tests/data/samples_large/timeline_A1_05_2024_10_08.tsv" 
+TIMELINE_FILE: "../../work-vp-test/variants/timeline.tsv" # "tests/data/samples_large/timeline_A1_05_2024_10_08.tsv"
 ### Output Files
 RESULTS_DIR:  "silo-inputs"
 
@@ -29,10 +29,12 @@ USERNAME: "testuser"
 PASSWORD: "testuser"
 
 ### LAPIS – hosting the SILO database (to query reference from)
+# Optional: specify LAPIS URL for custom reference genomes
+# If not provided, uses default SARS-CoV-2 references (NCBI Reference Sequence: NC_045512.2)
 LAPIS_URL: "http://88.198.54.174"
 
 ### Subsampling Configuration
 ## Subsampling 1) by fraction 2 by max reads or 3) by fraction, but max max_reads
 ENABLE_SUBSAMPLING: true
-# SUBSAMPLE_FRACTION: 0.5  
+# SUBSAMPLE_FRACTION: 0.5
 SUBSAMPLE_MAX_READS: 4500000  # keep of max of 4.5 Mio Reads


### PR DESCRIPTION
This pull request introduces robust and flexible reference genome handling in the `sr2silo` workflow, allowing users to specify a custom LAPIS server for reference retrieval or fall back to built-in SARS-CoV-2 references if none is provided or if the server is unavailable. The changes also update documentation, configuration files, and example scripts to reflect and explain this new behavior.

These changes make the workflow more user-friendly and robust for a variety of deployment scenarios.