### PR TITLE
fix: incomplete read merge

### DIFF
--- a/src/sr2silo/process/merge.py
+++ b/src/sr2silo/process/merge.py
@@ -40,7 +40,8 @@ def paired_end_read_merger(
         raise FileNotFoundError(f"File not found: {ref_genome_fasta_fp}")
 
     if output_merged_sam_fp.exists():
-        raise FileExistsError(f"File already exists: {output_merged_sam_fp}")
+        logger.info(f"Output file {output_merged_sam_fp} already exists. Overwriting.")
+        output_merged_sam_fp.unlink()
 
     if not is_sorted_qname(nuc_align_sam_fp):
         raise ValueError(f"Input file {nuc_align_sam_fp} is not sorted by QNAME.")


### PR DESCRIPTION

This pull request updates the behavior when the output file already exists in the paired-end read merger process. Instead of raising an error, the code now logs an informational message and overwrites the existing file.

File handling improvement:

* Changed the logic in `paired_end_read_merger` (in `merge.py`) to log a message and overwrite the output file if it already exists, instead of raising a `FileExistsError`.