### PR TITLE
release v1.3.0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,20 @@
+# Sample processing configuration
 SAMPLE_DIR=./../../../data/sr2silo/demo_real/A1_10_2024_09_30/20241018_AAG55WNM5/alignments/subsamples/1000/
 SAMPLE_ID=A1_10_2024_09_30
 BATCH_ID=20241018_AAG55WNM5
 TIMELINE_FILE=./../../../data/sr2silo/demo_real/timeline.tsv
 RESULTS_DIR=./../results/A1_10_2024_09_30/20241018_AAG55WNM5/1000/
+
+# Reference genome configuration (optional)
+# If not provided, uses default SARS-CoV-2 references (NCBI Reference Sequence: NC_045512.2)
+# LAPIS_URL=https://lapis.cov-spectrum.org/open/v2
+
+# Loculus authentication and submission
 KEYCLOAK_TOKEN_URL=https://authentication-wise-seqs.loculus.org/realms/loculus/protocol/openid-connect/token
 SUBMISSION_URL=https://backend-wise-seqs.loculus.org/test/submit?groupId={group_id}&dataUseTermsType=OPEN
 GROUP_ID=a
 USERNAME=testuser
 PASSWORD=testpassword
+
+# Environment configuration
 CI=False

--- a/README.md
+++ b/README.md
@@ -198,7 +198,6 @@ sr2silo process-from-vpipe \
     --input-file input.bam \
     --sample-id SAMPLE_001 \
     --timeline-file timeline.tsv \
-    --lapis-url https://lapis.cov-spectrum.org/open/v2 \
     --output-fp output.ndjson
 
 # Example: Submit to Loculus (use environment variables for credentials)
@@ -212,6 +211,8 @@ sr2silo submit-to-loculus --processed-file output.ndjson.zst
 ```
 
 **Note:** Use environment variables for credentials to avoid exposing sensitive information in command history.
+
+**Note:** The `--lapis-url` parameter is optional. If not provided, sr2silo uses default SARS-CoV-2 references (NC_045512.2). See `sr2silo process-from-vpipe --help` for details.
 
 ### Environment Variable Configuration
 
@@ -230,12 +231,11 @@ export GROUP_ID=123
 export USERNAME=your-username
 export PASSWORD=your-password
 
-# Run with required CLI arguments (timeline file must be specified)
+# Run with environment variables set
 sr2silo process-from-vpipe \
     --input-file input.bam \
     --sample-id SAMPLE_001 \
     --timeline-file /path/to/timeline.tsv \
-    --lapis-url https://lapis.cov-spectrum.org/open/v2 \
     --output-fp output.ndjson
 
 # Submission using environment variables for credentials

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,6 +1,6 @@
 # conda recipe
 {% set name = "sr2silo" %}
-{% set version = "1.2.0" %}
+{% set version = "1.3.0" %}
 
 package:
   name: {{ name|lower }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sr2silo"
-version = "1.2.0"
+version = "1.3.0"
 description = "ETL tool for importing short-read sequencing data into SILO database (v0.8.0+), powering Loculus."
 authors = ["Gordon Julian Koehn <gordon.koehn@dbsse.ethz.ch>"]
 readme = "README.md"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -6,15 +6,12 @@ INPUT_FILE="tests/data/samples_large/A1_05_2024_10_08/20241024_2411515907/alignm
 SAMPLE_ID="A1_05_2024_10_08"
 OUTPUT_FILE="./results_neo/silo_input.ndjson"
 TIMELINE_FILE="tests/data/samples_large/timeline_A1_05_2024_10_08.tsv"
-LAPIS_URL="https://lapis.cov-spectrum.org/open/v2"
 
 # Run using sr2silo CLI
-# Use submit-to-loculus command to upload and submit processed files to SILO
 sr2silo process-from-vpipe \
     --input-file "$INPUT_FILE" \
     --sample-id "$SAMPLE_ID" \
     --timeline-file "$TIMELINE_FILE" \
-    --lapis-url "$LAPIS_URL" \
     --output-fp "$OUTPUT_FILE"
 
 # Uncomment the following lines to upload and submit the processed file to SILO

--- a/src/sr2silo/process/interface.py
+++ b/src/sr2silo/process/interface.py
@@ -167,6 +167,9 @@ class AlignedRead:
 
         json_representation = {}
 
+        # Add read_id as the first field
+        json_representation["read_id"] = self.read_id
+
         # Add metadata at the start if available
         if self.metadata:
             metadata_dict = (

--- a/src/sr2silo/process/merge.py
+++ b/src/sr2silo/process/merge.py
@@ -40,7 +40,8 @@ def paired_end_read_merger(
         raise FileNotFoundError(f"File not found: {ref_genome_fasta_fp}")
 
     if output_merged_sam_fp.exists():
-        raise FileExistsError(f"File already exists: {output_merged_sam_fp}")
+        logger.info(f"Output file {output_merged_sam_fp} already exists. Overwriting.")
+        output_merged_sam_fp.unlink()
 
     if not is_sorted_qname(nuc_align_sam_fp):
         raise ValueError(f"Input file {nuc_align_sam_fp} is not sorted by QNAME.")

--- a/tests/process/test_interface.py
+++ b/tests/process/test_interface.py
@@ -342,6 +342,56 @@ def test_aa_insertion_set_equality():
     assert aa_set1 != "not_an_aa_insertion_set"
 
 
+def test_read_id_in_json_output():
+    """Test that read_id appears as the first field in JSON output."""
+    from sr2silo.process.interface import (
+        AAInsertionSet,
+        AASequenceSet,
+        AlignedRead,
+        GeneName,
+    )
+
+    read_id = "test_read_123"
+    read = AlignedRead(
+        read_id=read_id,
+        unaligned_nucleotide_sequence="ACTG",
+        aligned_nucleotide_sequence="ACTG",
+        aligned_nucleotide_sequence_offset=0,
+        nucleotide_insertions=[],
+        amino_acid_insertions=AAInsertionSet([GeneName("gene1")]),
+        aligned_amino_acid_sequences=AASequenceSet([GeneName("gene1")]),
+    )
+
+    # Test to_dict includes read_id
+    result_dict = read.to_dict()
+
+    # Check that read_id is present
+    assert "read_id" in result_dict, "read_id missing from to_dict() output"
+    assert (
+        result_dict["read_id"] == read_id
+    ), f"Expected {read_id}, got {result_dict['read_id']}"
+
+    # Check that read_id is the first key
+    first_key = list(result_dict.keys())[0]
+    assert (
+        first_key == "read_id"
+    ), f"read_id should be first key, but {first_key} was first"
+
+    # Test that the SILO JSON validation works with read_id
+    try:
+        json_output = read.to_silo_json()
+        assert json_output is not None
+
+        # Parse the JSON to verify structure
+        import json
+
+        parsed = json.loads(json_output)
+        assert "read_id" in parsed
+        assert parsed["read_id"] == read_id
+    except Exception as e:
+        pytest.fail(f"SILO JSON validation failed with read_id: {e}")
+
+
 def test_empty_gene_representation():
     """Test that genes with no sequence are represented as null."""
     from sr2silo.process.interface import (

--- a/tests/snakemake/process_sample/config.yaml
+++ b/tests/snakemake/process_sample/config.yaml
@@ -4,5 +4,6 @@ LOCATIONS:
 START_DATE: "2024-10-01"
 END_DATE: "2024-10-31"
 TIMELINE_FILE: "timeline_A1_05_2024_10_08.tsv"
+# Optional: LAPIS URL for custom reference genomes (falls back to SARS-CoV-2 defaults if unavailable)
 LAPIS_URL: "https://lapis.example.com"
 RESULTS_DIR: "results"

--- a/tests/snakemake/submit_to_loculus/config.yaml
+++ b/tests/snakemake/submit_to_loculus/config.yaml
@@ -4,6 +4,7 @@ LOCATIONS:
 START_DATE: "2024-10-01"
 END_DATE: "2024-10-31"
 TIMELINE_FILE: "timeline_A1_05_2024_10_08.tsv"
+# Optional: LAPIS URL for custom reference genomes (falls back to SARS-CoV-2 defaults if unavailable)
 LAPIS_URL: "https://lapis.cov-spectrum.org/open/v2"
 RESULTS_DIR: "results"
 

--- a/tests/test_silo_read_schema.py
+++ b/tests/test_silo_read_schema.py
@@ -129,8 +129,12 @@ def test_aligned_read_schema_without_metadata():
     """Test that an aligned read schema with minimal required fields is accepted."""
     from sr2silo.silo_read_schema import NucleotideSegment
 
-    minimal_data = {"main": NucleotideSegment(**VALID_MAIN_SEGMENT)}
+    minimal_data = {
+        "read_id": "test_read_123",
+        "main": NucleotideSegment(**VALID_MAIN_SEGMENT),
+    }
     aligned_read = AlignedReadSchema(**minimal_data)
+    assert aligned_read.read_id == "test_read_123"
     assert aligned_read.main.sequence == VALID_MAIN_SEGMENT["sequence"]
 
 

--- a/workflow/config.yaml
+++ b/workflow/config.yaml
@@ -13,7 +13,7 @@ END_DATE: "2025-07-15"
 
 ### Input Files
 BASE_SAMPLE_DIR:  "../results" # "tests/data/samples_large"
-TIMELINE_FILE: "../../work-vp-test/variants/timeline.tsv" # "tests/data/samples_large/timeline_A1_05_2024_10_08.tsv" 
+TIMELINE_FILE: "../../work-vp-test/variants/timeline.tsv" # "tests/data/samples_large/timeline_A1_05_2024_10_08.tsv"
 ### Output Files
 RESULTS_DIR:  "silo-inputs"
 
@@ -29,10 +29,12 @@ USERNAME: "testuser"
 PASSWORD: "testuser"
 
 ### LAPIS – hosting the SILO database (to query reference from)
+# Optional: specify LAPIS URL for custom reference genomes
+# If not provided, uses default SARS-CoV-2 references (NCBI Reference Sequence: NC_045512.2)
 LAPIS_URL: "http://88.198.54.174"
 
 ### Subsampling Configuration
 ## Subsampling 1) by fraction 2 by max reads or 3) by fraction, but max max_reads
 ENABLE_SUBSAMPLING: true
-# SUBSAMPLE_FRACTION: 0.5  
+# SUBSAMPLE_FRACTION: 0.5
 SUBSAMPLE_MAX_READS: 4500000  # keep of max of 4.5 Mio Reads


### PR DESCRIPTION
This pull request introduces several improvements to the handling of reference genomes and the SILO JSON schema, along with updates to documentation and configuration. The most significant changes are the addition of a required `read_id` field in the SILO schema, improved logic for selecting reference genomes (with fallback to SARS-CoV-2 defaults), and corresponding updates to documentation, tests, and configuration files.

**Reference genome handling and configuration:**

* Added logic to use a default SARS-CoV-2 reference genome (NCBI Reference Sequence: NC_045512.2) if no LAPIS URL is provided or if fetching from LAPIS fails. This is implemented via a new `_get_reference_files` function in `src/sr2silo/main.py`, and the CLI option `--lapis-url` is now optional. Logging and fallback behavior have been improved for clarity. [[1]](diffhunk://#diff-a1d6dd10f0c9672f89af36937b68b83c0902089a58ff9917f08400101de4a092L27-R93) [[2]](diffhunk://#diff-a1d6dd10f0c9672f89af36937b68b83c0902089a58ff9917f08400101de4a092L85-R155) [[3]](diffhunk://#diff-a1d6dd10f0c9672f89af36937b68b83c0902089a58ff9917f08400101de4a092R183-R186) [[4]](diffhunk://#diff-a1d6dd10f0c9672f89af36937b68b83c0902089a58ff9917f08400101de4a092L141-R208)
* Updated documentation (`README.md`, `.env.example`, and various config files) to clarify that the LAPIS URL is optional and to document the fallback behavior. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L201) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R215-R216) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L233-L238) [[4]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR1-R19) [[5]](diffhunk://#diff-2d085a26a07d96536c6c7815327575f4095448c090b9bce3a8be73d109330bfeR7) [[6]](diffhunk://#diff-526695dcde4bb8731d234d4c6c8696a0fc1b6bf631dba870b7834a9118794872R7) [[7]](diffhunk://#diff-53979815916e8fe6354eddc998db73b9d65eaf254fd1cdd36d98e527ea7529d3R32-R33)
* Updated example scripts and configs to make the use of LAPIS URL optional and consistent with the new logic.

**SILO JSON schema and validation:**

* Made `read_id` a required field at the root level of the SILO JSON schema (`AlignedReadSchema` in `src/sr2silo/silo_read_schema.py`), and updated the validation logic to check for its presence and correct type. [[1]](diffhunk://#diff-34b29cb323a8f5dfa53e1eb6099e61bb033b5899acbe080f483f74993c265e97R191-R200) [[2]](diffhunk://#diff-34b29cb323a8f5dfa53e1eb6099e61bb033b5899acbe080f483f74993c265e97L205-R214) [[3]](diffhunk://#diff-34b29cb323a8f5dfa53e1eb6099e61bb033b5899acbe080f483f74993c265e97L234-R254)
* Modified the `AlignedRead.to_dict()` method to ensure `read_id` is the first field in the output dictionary, improving consistency and downstream parsing.

**Testing and robustness:**

* Added tests to verify that `read_id` is present and is the first field in the JSON output, and that the updated schema validation works as expected. [[1]](diffhunk://#diff-ebc1e5b3ff30600dce69ff0591fd7ef26041cd2d9262b38bffc1562d7f797faaR345-R394) [[2]](diffhunk://#diff-0622b17911304d4ac314deeb4a97de937604fd1e87210516560ba0ff709fdb63L132-R137)
* Improved file handling in the paired-end read merger to overwrite existing output files rather than raising an error, making workflows more robust.