### PR TITLE
workflow: adding retries and update to new conda package

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -370,6 +370,7 @@ rule process_sample:
         "logs/sr2silo/process_sample/sampleId_{sample_id}.log",
     conda:
         "envs/sr2silo.yaml"
+    retries: 3
     shell:
         """
         sr2silo process-from-vpipe \

--- a/workflow/envs/sr2silo.yaml
+++ b/workflow/envs/sr2silo.yaml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - sr2silo=1.2.0
+  - sr2silo=1.3.0
   - snakemake=8.18  # fixed as snakemake unit tests fail with 8.19
   - diamond>=2.1.0
   - smallgenomeutilities>=0.5.2


### PR DESCRIPTION
This PR updates the workflow to:

- retries the process sample rule because SLURM on EULER is flaky
- bump to the new conda environment