### PR TITLE
chore: workflow bump verison

### DIFF
--- a/workflow/envs/sr2silo.yaml
+++ b/workflow/envs/sr2silo.yaml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - sr2silo=1.3.0
+  - sr2silo=1.4.0
   - snakemake=8.18  # fixed as snakemake unit tests fail with 8.19
   - diamond>=2.1.0
   - smallgenomeutilities>=0.5.2


### PR DESCRIPTION
This pull request updates the `sr2silo` dependency in the `workflow/envs/sr2silo.yaml` environment file to a newer version.

Dependency updates:

* Upgraded the `sr2silo` package from version 1.3.0 to 1.4.0 in `workflow/envs/sr2silo.yaml`.