### PR TITLE
feat: add --auto-release option to submit-to-loculus command

### DIFF
--- a/deployments/_templates/config.yaml
+++ b/deployments/_templates/config.yaml
@@ -17,7 +17,7 @@ LOCATIONS:
 # Supports both explicit dates (YYYY-MM-DD) and relative dates:
 # - "TODAY" → current date
 # - "1_WEEK_AGO" or "1_WEEKS_AGO" → 1 week back
-# - "2_WEEKS_AGO" → 2 weeks back  
+# - "2_WEEKS_AGO" → 2 weeks back
 # - "1_MONTH_AGO" or "1_MONTHS_AGO" → 1 month back
 # - "3_MONTHS_AGO" → 3 months back
 # - "30_DAYS_AGO" → 30 days back
@@ -42,11 +42,16 @@ LOG_DIR: "../../logs/template"
 
 ### Loculus (to submit results to)
 ## URLs for Loculus services
-LOCULUS:
-  KEYCLOAK_TOKEN_URL: "https://auth.db.wasap.genspectrum.org/realms/loculus/protocol/openid-connect/token"
-  BACKEND_URL: "https://api.db.wasap.genspectrum.org/backend"
-  GROUP_ID: 1                               # Unique ID per virus
-  ORGANISM: "template"                      # Must match SILO database
+KEYCLOAK_TOKEN_URL: "https://auth.db.wasap.genspectrum.org/realms/loculus/protocol/openid-connect/token"
+BACKEND_URL: "https://api.db.wasap.genspectrum.org/backend"
+GROUP_ID: 1                                 # Unique ID per virus
+ORGANISM: "template"                        # Must match SILO database
+
+## Auto-release configuration
+# If true, automatically release/approve sequences after submission
+# This waits RELEASE_DELAY seconds to allow backend processing, then releases
+AUTO_RELEASE: false
+RELEASE_DELAY: 180                          # Seconds to wait before releasing (default: 3 minutes)
 
 ## Authentication credentials
 # NOTE: USERNAME and PASSWORD are loaded from encrypted secrets/credentials.enc

--- a/deployments/covid/config.yaml
+++ b/deployments/covid/config.yaml
@@ -31,6 +31,10 @@ GROUP_ID: 1
 ORGANISM: "covid"
 LAPIS_URL: "https://lapis.wasap.genspectrum.org/"
 
+# Auto-release: automatically approve sequences after submission
+AUTO_RELEASE: false
+RELEASE_DELAY: 180  # Seconds to wait before releasing
+
 # Credentials loaded from secrets/credentials.enc at runtime via secrets.py
 # Do NOT include plaintext USERNAME or PASSWORD here
 

--- a/deployments/rsva/config.yaml
+++ b/deployments/rsva/config.yaml
@@ -29,7 +29,11 @@ KEYCLOAK_TOKEN_URL: "https://auth.db.wasap.genspectrum.org/realms/loculus/protoc
 BACKEND_URL: "https://api.db.wasap.genspectrum.org/backend"
 GROUP_ID: 1
 ORGANISM: "rsva"
-# LAPIS_URL: 
+# LAPIS_URL:
+
+# Auto-release: automatically approve sequences after submission
+AUTO_RELEASE: true
+RELEASE_DELAY: 180  # Seconds to wait before releasing
 
 # Credentials loaded from secrets/credentials.enc at runtime via decrypt.py
 # Do NOT include plaintext USERNAME or PASSWORD here

--- a/src/sr2silo/config.py
+++ b/src/sr2silo/config.py
@@ -181,6 +181,27 @@ def get_password(default: str | None = None) -> str:
     return password
 
 
+def get_auto_release(default: bool = False) -> bool:
+    """Get the auto-release setting from environment.
+
+    Args:
+        default: Default value if environment variable is not set (default: False)
+
+    Returns:
+        bool: Whether to automatically release sequences after submission
+    """
+    auto_release = os.getenv("AUTO_RELEASE", "").lower()
+    if auto_release in ("yes", "true", "t", "1"):
+        return True
+    elif auto_release in ("no", "false", "f", "0", ""):
+        return default
+    else:
+        logging.warning(
+            f"Invalid AUTO_RELEASE value '{auto_release}', using default: {default}"
+        )
+        return default
+
+
 def get_mock_urls() -> tuple[str, str]:
     """Get mock URLs for CI environment.
 

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -133,7 +133,7 @@ def get_sample_list():
         header = next(reader, None)
         if not header:
             return sample_list
-        
+
         # Build column index map - support both COVID and RSV-A column names
         col_map = {name: idx for idx, name in enumerate(header)}
         # Sample column: "sample" (COVID) or "submissionId" (RSV-A)
@@ -141,12 +141,12 @@ def get_sample_list():
         batch_col = col_map.get("batch", 1)
         location_code_col = col_map.get("location_code", 5)
         date_col = col_map.get("date", 6)
-        
+
         # Process all data rows
         for row in reader:
             if len(row) <= max(sample_col, batch_col, location_code_col, date_col):
                 continue  # Skip invalid rows
-            
+
             sample = row[sample_col]
             date_str = row[date_col]
             location_code = row[location_code_col]
@@ -198,7 +198,7 @@ def get_input_file_path(sample_id):
         header = next(reader, None)
         if not header:
             return str(simple_path)
-        
+
         col_map = {name: idx for idx, name in enumerate(header)}
         sample_col = col_map.get("sample", col_map.get("submissionId", 0))
         batch_col = col_map.get("batch", 1)
@@ -505,6 +505,10 @@ rule submit_to_loculus:
         - PASSWORD (environment variable, set by secrets.py)
         - ORGANISM
 
+    Optional configuration:
+        - AUTO_RELEASE: If true, automatically release sequences after submission
+        - RELEASE_DELAY: Seconds to wait before releasing (default: 180)
+
     CLI parameters take precedence over environment variables.
 
     Note: On ETH cluster, internet access is provided by eth_proxy module loaded at job level.
@@ -522,6 +526,8 @@ rule submit_to_loculus:
         username=os.environ.get("USERNAME", ""),
         password=os.environ.get("PASSWORD", ""),
         organism=config.get("ORGANISM", ""),
+        auto_release="--auto-release" if config.get("AUTO_RELEASE", False) else "",
+        release_delay=config.get("RELEASE_DELAY", 180),
     log:
         f"{config['LOG_DIR']}/sr2silo/submit_to_loculus/sampleId_{{sample_id}}.log",
     conda:
@@ -536,7 +542,9 @@ rule submit_to_loculus:
             --group-id {params.group_id} \
             --organism "{params.organism}" \
             --username "{params.username}" \
-            --password "{params.password}" > {log} 2>&1 && \
+            --password "{params.password}" \
+            {params.auto_release} \
+            --release-delay {params.release_delay} > {log} 2>&1 && \
         mkdir -p $(dirname {output.flag}) && \
         touch {output.flag}
         """


### PR DESCRIPTION
## Summary
- Add optional `--auto-release` / `-r` flag to automatically approve/release sequences after submission
- Add `--release-delay` option (default 180 seconds) to wait for backend processing before release
- Add `AUTO_RELEASE` environment variable support

This mirrors the release functionality from [WISE-mut-freq-data-uploader](https://github.com/GenSpectrum/WISE-mut-freq-data-uploader/blob/main/scripts/upload_data.py#L139).

## Changes
- **loculus.py**: Add `approve_all()` method to `LoculusClient` that calls `POST /{organism}/approve-processed-data`
- **submit_to_loculus.py**: Add auto-release logic after successful submission
- **main.py**: Add CLI options `--auto-release` and `--release-delay`
- **config.py**: Add `get_auto_release()` helper for environment variable
- **test_loculus.py**: Add unit tests for `approve_all()` method

## Usage
```bash
# Enable auto-release via CLI flag
sr2silo submit-to-loculus -f data.ndjson.zst -a alignment.bam --auto-release

# With custom delay (60 seconds instead of default 180)
sr2silo submit-to-loculus -f data.ndjson.zst -a alignment.bam --auto-release --release-delay 60

# Or via environment variable
export AUTO_RELEASE=true
sr2silo submit-to-loculus -f data.ndjson.zst -a alignment.bam
```

## Test plan
- [x] Unit tests for `approve_all()` method pass
- [x] Existing `submit-to-loculus` tests pass
- [x] CLI help shows new options
- [x] CI environment mock behavior verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)