### PR TITLE
Add --timeline-config CLI option for external column mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,20 +36,20 @@ conda install -c bioconda sr2silo
 
 Processing BAM data:
 
+```=bash
+span
+```
+
+Submitting to Loculus:
+
 ```bash
 sr2silo process-from-vpipe \
     --input-file input.bam \
     --sample-id SAMPLE_001 \
     --timeline-file timeline.tsv \
     --organism covid \
-    --output-fp output.ndjson.zst
-```
-
-Submitting to Loculus:
-
-```bash
-sr2silo submit-to-loculus \
-    --processed-file output.ndjson.zst
+    --output-fp output.ndjson.zst \
+    --timeline-config /path/to/timeline_columns.yml  # optional, overrides bundled column mappings
 ```
 
 ## Documentation

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -17,15 +17,17 @@ Environment variables provide configuration defaults. CLI arguments override env
 
 ### Processing Configuration (process-from-vpipe)
 
-| Variable | Purpose | Default | Example |
-|----------|---------|---------|---------|
-| `ORGANISM` | Organism identifier | None (required) | `covid`, `rsva` |
-| `TIMELINE_FILE` | Metadata timeline file | None (required) | `/path/to/timeline.tsv` |
-| `LAPIS_URL` | LAPIS instance URL (optional) | None | `https://lapis.example.com` |
-| `NUC_REF` | Nucleotide reference FASTA | None | `/path/to/nuc_ref.fasta` |
-| `AA_REF` | Amino acid reference FASTA | None | `/path/to/aa_ref.fasta` |
-| `REFERENCE_ACCESSION` | Filter reads by reference accession | `""` (all reads) | `EPI_ISL_412866` |
-| `XDG_CACHE_HOME` | Override cache location | `~/.cache` | `/scratch/.cache` |
+
+| Variable              | Purpose                             | Default             | Example                           |
+| --------------------- | ----------------------------------- | ------------------- | --------------------------------- |
+| `ORGANISM`            | Organism identifier                 | None (required)     | `covid`, `rsva`                   |
+| `TIMELINE_FILE`       | Metadata timeline file              | None (required)     | `/path/to/timeline.tsv            |
+| `TIMELINE_CONFIG`    | External timeline columns YAML file | None (uses bundled) | \`/path/to/timeline\_columns.yml` |
+| `LAPIS_URL`           | LAPIS instance URL (optional)       | None                | `https://lapis.example.com`       |
+| `NUC_REF`             | Nucleotide reference FASTA          | None                | `/path/to/nuc_ref.fasta`          |
+| `AA_REF`              | Amino acid reference FASTA          | None                | `/path/to/aa_ref.fasta`           |
+| `REFERENCE_ACCESSION` | Filter reads by reference accession | `""` (all reads)    | `EPI_ISL_412866`                  |
+| `XDG_CACHE_HOME`      | Override cache location             | `~/.cache`          | `/scratch/.cache`                 |
 
 #### Reference Files
 
@@ -86,17 +88,46 @@ samtools view -H file.bam | grep @SQ
 
 If filtering results in zero reads, processing terminates with a `ZeroFilteredReadsError`.
 
+#### Timeline Column Mappings
+
+By default, sr2silo uses a bundled `timeline_columns.yml` to map internal field names to timeline TSV column names for each organism. To use a custom mapping file instead (e.g. for a new organism without cutting a release):
+
+```bash
+sr2silo process-from-vpipe \
+  --input-file alignments.bam \
+  --timeline-config /path/to/timeline_columns.yml \
+  --organism rsvb \
+  ...
+```
+
+The file must follow this format:
+
+```yaml
+organisms:
+  rsvb:
+    sample_id: submissionId
+    batch_id: batch
+    read_length: reads
+    primer_protocol: primerProtocol
+    location_code: location_code
+    sampling_date: date
+    location_name: location
+```
+
+Can also be set via the `TIMELINE_CONFIG` environment variable.
+
 ### Submission Configuration (submit-to-loculus)
 
-| Variable | Purpose | Default | Example |
-|----------|---------|---------|---------|
-| `ORGANISM` | Organism identifier | None (required) | `covid`, `rsva` |
-| `KEYCLOAK_TOKEN_URL` | Authentication endpoint | None (required) | `https://auth.example.com/token` |
-| `BACKEND_URL` | SILO backend API endpoint | None (required) | `https://api.example.com/api` |
-| `GROUP_ID` | Loculus group ID | None (required) | `1`, `42` |
-| `USERNAME` | Submission username | None (required) | Your username |
-| `PASSWORD` | Submission password | None (required) | Your password |
-| `AUTO_RELEASE` | Auto-approve sequences after submission | `false` | `true` |
+
+| Variable             | Purpose                                 | Default         | Example                          |
+| -------------------- | --------------------------------------- | --------------- | -------------------------------- |
+| `ORGANISM`           | Organism identifier                     | None (required) | `covid`, `rsva`                  |
+| `KEYCLOAK_TOKEN_URL` | Authentication endpoint                 | None (required) | `https://auth.example.com/token` |
+| `BACKEND_URL`        | SILO backend API endpoint               | None (required) | `https://api.example.com/api`    |
+| `GROUP_ID`           | Loculus group ID                        | None (required) | `1`, `42`                        |
+| `USERNAME`           | Submission username                     | None (required) | Your username                    |
+| `PASSWORD`           | Submission password                     | None (required) | Your password                    |
+| `AUTO_RELEASE`       | Auto-approve sequences after submission | `false`         | `true`                           |
 
 #### Auto-Release
 
@@ -126,6 +157,7 @@ The `--release-delay` option (default 180s) allows backend processing time befor
 ## Snakemake Workflow
 
 Configure in `workflow/config.yaml`:
+
 ```yaml
 ORGANISM: "covid"
 REFERENCE_ACCESSION: ""  # Filter reads by reference (use for RSV-A/B)

--- a/docs/usage/organisms.md
+++ b/docs/usage/organisms.md
@@ -4,10 +4,12 @@ sr2silo supports processing samples from multiple organisms with organism-specif
 
 ## Supported Organisms
 
-| Organism | Identifier | Description |
-|----------|------------|-------------|
-| COVID-19 | `covid` | SARS-CoV-2 / Severe acute respiratory syndrome coronavirus 2 |
-| RSV-A | `rsva` | Respiratory Syncytial Virus A |
+
+| Organism | Identifier | Description                                                  |
+| -------- | ---------- | ------------------------------------------------------------ |
+| COVID-19 | `covid`    | SARS-CoV-2 / Severe acute respiratory syndrome coronavirus 2 |
+| RSV-A    | `rsva`     | Respiratory Syncytial Virus A<br />                          |
+| RSV-B    | `rsvb`     | Respiratory Syncytial Virus B                                |
 
 ## Reference Resolution
 
@@ -22,6 +24,7 @@ This allows for both static local references and dynamic references from a LAPIS
 ## Usage
 
 For detailed usage, see:
+
 ```bash
 sr2silo process-from-vpipe --help
 ```
@@ -33,28 +36,31 @@ The `--organism` parameter specifies which organism to process. Can also be set 
 To add support for a new organism:
 
 1. **Add reference files** to `resources/references/{organism_id}/`:
+
    - `nuc_ref.fasta` - Nucleotide reference sequence(s)
    - `aa_ref.fasta` - Amino acid reference sequences for gene annotations
-
 2. **Use GenBank parser** (if starting from GenBank format):
+
    ```bash
    python scripts/extract_gbk_references.py \
        reference.gbk \
        --nuc-output resources/references/{organism_id}/nuc_ref.fasta \
        --aa-output resources/references/{organism_id}/aa_ref.fasta
    ```
+3. **Update configuration**:
 
-3. **Update configuration** (optional):
+   - Add your organism's column mappings to a **\`timeline\_columns.yml\`** file and pass it via **\`--timeline-config\`** (or **\`TIMELINE\_CONFIG\`** env var) — no new release needed
    - Update workflow `config.yaml` with your new organism ID
    - Update documentation with organism details
-
 4. **Test** (optional):
+
    - Add test fixtures in `tests/conftest.py`
    - Add parameterized tests in `tests/test_main.py`
 
 ## Workflow Integration
 
 Specify organism in `workflow/config.yaml`:
+
 ```yaml
 ORGANISM: "covid"  # or "rsva"
 ```
@@ -62,6 +68,7 @@ ORGANISM: "covid"  # or "rsva"
 ## Troubleshooting
 
 **Reference files not found:**
+
 - Verify files exist: `ls resources/references/{organism}/`
 - Check organism identifier spelling
 - Use `--lapis-url` to fetch from LAPIS

--- a/src/sr2silo/config.py
+++ b/src/sr2silo/config.py
@@ -259,25 +259,29 @@ def get_aa_ref(default: Path | None = None) -> Path | None:
     return Path(aa_ref) if aa_ref else default
 
 
-def get_timeline_column_mappings(organism: str) -> dict[str, str]:
+def get_timeline_column_mappings(organism: str, config_path: Path | None = None) -> dict[str, str]:
     """Get timeline column name mappings for a specific organism.
 
-    Uses importlib.resources to load config from package data.
-    Falls back to default mappings if config not found.
+        Uses importlib.resources to load config from package data.
+        Falls back to default mappings if config not found.
+        If config_path is provided, reads from that file instead of the bundled one.
 
-    Args:
-        organism: The organism identifier (e.g., 'covid', 'rsva')
+        Args:
+            organism: The organism identifier (e.g., 'covid', 'rsva')
+            config_path: Optional path to an external timeline columns YAML file.
+                         If provided, this file is used instead of the bundled one.
 
-    Returns:
-        dict[str, str]: Mapping from internal names to timeline column names.
-                       Default mappings are used if organism config not found.
+        Returns:
+            dict[str, str]: Mapping from internal names to timeline column names.
+                           Default mappings are used if organism config not found.
 
-    Examples:
-        >>> mappings = get_timeline_column_mappings('covid')
-        >>> mappings['sample_id']  # Returns 'sample'
-        >>> mappings = get_timeline_column_mappings('rsva')
-        >>> mappings['sample_id']  # Returns 'submissionId'
-    """
+        Examples:
+            >>> mappings = get_timeline_column_mappings('covid')
+            >>> mappings['sample_id']  # Returns 'sample'
+            >>> mappings = get_timeline_column_mappings('rsva')
+            >>> mappings['sample_id']  # Returns 'submissionId'
+        """
+
     # Default mappings (backward compatible with COVID timeline format)
     default_mappings = {
         "sample_id": "sample",
@@ -288,9 +292,28 @@ def get_timeline_column_mappings(organism: str) -> dict[str, str]:
         "sampling_date": "date",
         "location_name": "location",
     }
+    # If an external config file is provided, use it exclusively
+    if config_path is not None:
+        if not config_path.exists():
+            raise FileNotFoundError(
+                f"Timeline config file not found: {config_path}"
+            )
 
+        config_text = config_path.read_text()
+        config = yaml.safe_load(config_text)
+        if config and "organisms" in config and organism in config["organisms"]:
+            mappings = config["organisms"][organism]
+            logging.debug(f"Loaded timeline column mappings for {organism} from {config_path}: {mappings}")
+            return mappings
+        else:
+            raise ValueError(
+                f"No timeline column mappings found for organism '{organism}' "
+                f"in {config_path}. Available organisms: "
+                f"{list(config.get('organisms', {}).keys())}"
+            )
+
+    # otherwise use the bundled package file (existing behavior)
     try:
-        # Use importlib.resources for proper package resource access
         from importlib.resources import files
 
         config_file = files("sr2silo.data").joinpath("timeline_columns.yml")

--- a/src/sr2silo/main.py
+++ b/src/sr2silo/main.py
@@ -210,6 +210,15 @@ def process_from_vpipe(
             "If not specified, all reads are processed.",
         ),
     ] = None,
+    timeline_config: Annotated[
+        Path | None,
+        typer.Option(
+            "--timeline-config",
+            help="Path to and external timeline columns YAML file. "
+                 "If provided, used instead of the bundled one. "
+                 "Useful for adding new organisms without a new release.",
+        ),
+    ] = None,
 ) -> None:
     """
     V-PIPE to SILO conversion with amino acids and special metadata.
@@ -280,6 +289,7 @@ def process_from_vpipe(
         version_info=version_info,
         organism=organism,
         reference_accession=reference_accession,
+        config_path=timeline_config
     )
 
 

--- a/src/sr2silo/process_from_vpipe.py
+++ b/src/sr2silo/process_from_vpipe.py
@@ -51,6 +51,7 @@ def nuc_align_to_silo_njson(
     version_info: str | None = None,
     organism: str = "covid",
     reference_accession: str | None = None,
+    config_path: Path | None = None,
 ) -> bool:
     """Process a given input file.
 
@@ -70,6 +71,8 @@ def nuc_align_to_silo_njson(
         reference_accession (str | None): Filter reads to only include those
                        aligned to this reference accession. Should match @SQ SN
                        field in BAM header. If None, all reads are processed.
+        config_path (Path | None): Optional path to an external timeline columns
+                       YAML file. If provided, used instead of the bundled one.
 
     Returns:
         bool: True if processing was performed, False if skipped (0 reads).
@@ -111,7 +114,7 @@ def nuc_align_to_silo_njson(
     logging.info(f"Processing file: {input_file}")
 
     ##### Get Sample and Batch metadata and write to a file #####
-    sample_to_process = Sample(sample_id, organism=organism)
+    sample_to_process = Sample(sample_id, organism=organism, config_path=config_path)
     sample_to_process.enrich_metadata(timeline_file)
     metadata = sample_to_process.get_metadata()
 

--- a/src/sr2silo/vpipe/metadata.py
+++ b/src/sr2silo/vpipe/metadata.py
@@ -35,8 +35,7 @@ def convert_to_iso_date(date: str) -> str:
 
 
 def get_metadata_from_timeline(
-    sample_id: str, timeline: Path, organism: str = "covid"
-) -> dict[str, str] | None:
+    sample_id: str, timeline: Path, organism: str = "covid", config_path: Path | None = None) -> dict[str, str] | None:
     """Get metadata from the timeline file.
 
     Args:
@@ -44,6 +43,8 @@ def get_metadata_from_timeline(
         timeline (Path): The timeline file to search in.
         organism (str): The organism identifier (e.g., 'covid', 'rsva').
                        Used to determine timeline column name mappings.
+        config_path (Path | None): Optional path to an external timeline columns
+                       YAML file. If provided, used instead of the bundled one.
 
     Returns:
         dict[str, str] | None: The metadata if found, None otherwise.
@@ -58,7 +59,7 @@ def get_metadata_from_timeline(
         raise FileNotFoundError(f"Timeline file not found or is not a file: {timeline}")
 
     # Get organism-specific column mappings
-    col_map = get_timeline_column_mappings(organism)
+    col_map = get_timeline_column_mappings(organism, config_path)
     logging.debug(f"Using timeline column mappings for {organism}: {col_map}")
 
     with timeline.open() as f:
@@ -134,7 +135,7 @@ def get_metadata_from_timeline(
 
 
 def get_metadata(
-    sample_id: str, timeline: Path, organism: str = "covid"
+    sample_id: str, timeline: Path, organism: str = "covid", config_path: Path | None = None
 ) -> dict[str, str]:
     """
     Get metadata for a given sample from timeline file only.
@@ -144,6 +145,8 @@ def get_metadata(
         timeline (Path): The timeline file to cross-reference the metadata.
         organism (str): The organism identifier (e.g., 'covid', 'rsva').
                        Used to determine timeline column name mappings.
+        config_path (Path | None): Optional path to an external timeline columns
+                       YAML file. If provided, used instead of the bundled one.
 
     Returns:
         dict: A dictionary containing the metadata, or empty dict if not found.
@@ -156,7 +159,7 @@ def get_metadata(
     if not sample_id or not sample_id.strip():
         raise ValueError("Sample ID cannot be empty")
 
-    metadata = get_metadata_from_timeline(sample_id, timeline, organism)
+    metadata = get_metadata_from_timeline(sample_id, timeline, organism, config_path)
 
     if metadata is None:
         # Return basic metadata structure if not found in timeline

--- a/src/sr2silo/vpipe/sample.py
+++ b/src/sr2silo/vpipe/sample.py
@@ -14,11 +14,14 @@ class Sample:
         sample_id (str): The sample ID.
         organism (str): The organism identifier (e.g., 'covid', 'rsva').
                        Optional, defaults to 'covid' for backward compatibility.
+        config_path (Path | None): Optional path to an external timeline columns
+                           YAML file. If provided, used instead of the bundled one.
     """
 
-    def __init__(self, sample_id: str, organism: str = "covid") -> None:
+    def __init__(self, sample_id: str, organism: str = "covid", config_path: Path | None = None) -> None:
         self.sample_id = sample_id
         self.organism = organism
+        self.config_path = config_path
         self.metadata: dict[str, str] | None = None
         self.timeline: Path | None = None
 
@@ -42,6 +45,7 @@ class Sample:
             sample_id=self.sample_id,
             timeline=self.timeline,
             organism=self.organism,
+            config_path=self.config_path,
         )
 
     def get_metadata(self) -> dict[str, str]:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,6 +7,9 @@ import importlib.metadata
 import os
 from pathlib import Path
 from unittest.mock import patch
+import yaml
+import pytest
+
 
 from sr2silo.config import (
     get_backend_url,
@@ -224,3 +227,45 @@ def test_get_timeline_column_mappings_has_required_fields():
             f"Organism {organism} is missing required fields. "
             f"Expected: {required_fields}, Got: {set(mappings.keys())}"
         )
+
+
+def test_get_timeline_column_mappings_external_file(tmp_path):
+    """Test get_timeline_column_mappings with an external config file."""
+    # Create a temporary YAML file with rsvb
+    config = {
+        "organisms": {
+            "rsvb": {
+                "sample_id": "submissionId",
+                "batch_id": "batch",
+                "read_length": "reads",
+                "primer_protocol": "primerProtocol",
+                "location_code": "location_code",
+                "sampling_date": "date",
+                "location_name": "location",
+            }
+        }
+    }
+    config_file = tmp_path / "timeline_columns.yml"
+    config_file.write_text(yaml.dump(config))
+
+    mappings = get_timeline_column_mappings("rsvb", config_path=config_file)
+    assert mappings["sample_id"] == "submissionId"
+    assert mappings["primer_protocol"] == "primerProtocol"
+
+def test_get_timeline_column_mappings_external_file_organism_not_found(tmp_path):
+    """Test that ValueError is raised when organism not found in external file."""
+    config = {"organisms": {"covid": {"sample_id": "sample"}}}
+    config_file = tmp_path / "timeline_columns.yml"
+    config_file.write_text(yaml.dump(config))
+
+    with pytest.raises(ValueError, match="rsvb"):
+        get_timeline_column_mappings("rsvb", config_path=config_file)
+
+
+def test_get_timeline_column_mappings_external_file_not_found(tmp_path):
+    """Test that FileNotFoundError is raised when external file does not exist."""
+    non_existent = tmp_path / "does_not_exist.yml"
+
+    with pytest.raises(FileNotFoundError):
+        get_timeline_column_mappings("rsvb", config_path=non_existent)
+


### PR DESCRIPTION
Here's a PR description you can copy:

---

**Problem**

sr2silo uses a `timeline_columns.yml` file bundled inside the Python package to map internal field names to timeline TSV column names for each organism. Adding or updating a virus configuration requires either:
- cutting a new release with the updated file baked in, or
- manually overwriting the installed file on the server 

The bundled file is currently out of date and missing `rsvb`.

Additionally, when an organism is not found in the bundled file, sr2silo silently falls back to COVID column mappings, which causes empty/wrong metadata without any error.

**Solution**

Add a `--timeline-config` CLI option to `process-from-vpipe` that lets you point to an external YAML file instead of the bundled one:

```bash
sr2silo process-from-vpipe \
  --input-file alignments.bam \
  --organism rsvb \
  --timeline-config /path/to/timeline_columns.yml \
  ...
```

Also configurable via the `TIMELINE_CONFIG` environment variable.

When `--timeline-config` is provided and the organism is not found in it, sr2silo now errors loudly instead of silently falling back to COVID defaults.

**Changes**
- `src/sr2silo/config.py` — `get_timeline_column_mappings` accepts optional `config_path`
- `src/sr2silo/vpipe/metadata.py` — thread `config_path` through
- `src/sr2silo/vpipe/sample.py` — thread `config_path` through
- `src/sr2silo/process_from_vpipe.py` — thread `config_path` through
- `src/sr2silo/main.py` — add `--timeline-config` CLI flag
- `tests/test_config.py` — add tests for new behavior
- `README.md`, `docs/usage/configuration.md`, `docs/usage/organisms.md` — update docs